### PR TITLE
Personnalisation du déploiement Clever Cloud

### DIFF
--- a/clevercloud/http.json
+++ b/clevercloud/http.json
@@ -1,0 +1,4 @@
+{
+    "force_https": true,
+    "charset": "utf-8"
+}

--- a/clevercloud/python.json
+++ b/clevercloud/python.json
@@ -1,0 +1,12 @@
+{
+    "build": {
+        "cache_dependancies": true
+    },
+    "deploy": {
+        "module": "config.wsgi:application",
+        "managetasks": [
+            "migrate --no-input",
+            "collectstatic --no-input"
+        ]
+    }
+}


### PR DESCRIPTION
### Quoi ?

Personnalisation du déploiement pour Clever Cloud

### Pourquoi ?

Pour ajouter les commandes de déploiement de DJANGO (migrate et collectstatic), mettre en cache les dépendances, et forcer le HTTPS et l'encodage.

### Comment ?

En créant les fichiers `http.json` et `python.json` que Clever Cloud sait interpréter.