### PR TITLE
Désactiver l'utilisation de la signature lors des publication

### DIFF
--- a/lacommunaute/templates/forum_conversation/partials/post_form.html
+++ b/lacommunaute/templates/forum_conversation/partials/post_form.html
@@ -29,14 +29,6 @@
             <br />
             <div class="row">
                 <div class="col-md-12">
-                    {% with field=post_form.enable_signature %}
-                        <div class="checkbox">
-                            <label for="{{ field.auto_id }}">
-                                {{ field }}
-                                {{ field.label }}
-                            </label>
-                        </div>
-                    {% endwith %}
                     {% if post_form.lock_topic %}
                         {% with field=post_form.lock_topic %}
                             <div class="checkbox">

--- a/lacommunaute/templates/forum_conversation/partials/topic_form.html
+++ b/lacommunaute/templates/forum_conversation/partials/topic_form.html
@@ -32,15 +32,6 @@
                 <br />
                 <div class="row">
                     <div class="col-md-12">
-                        {% include "partials/form_field.html" with field=post_form.topic_type %}
-                        {% with field=post_form.enable_signature %}
-                            <div class="checkbox">
-                                <label for="{{ field.auto_id }}">
-                                    {{ field }}
-                                    {{ field.label }}
-                                </label>
-                            </div>
-                        {% endwith %}
                         {% if post_form.lock_topic %}
                             {% with field=post_form.lock_topic %}
                                 <div class="checkbox">


### PR DESCRIPTION
### Quoi ?

- Désactiver l'utilisation de la signature lors des publication

### Pourquoi ?

- Signature : pour ne pas à avoir à gérer leur affichage dans les nouveaux threads

### Comment ?

- Signature : surcharge des templates machina