### PR TITLE
Ajout de la bonne URL d'authentification

### DIFF
--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -85,6 +85,7 @@ MIDDLEWARE = [
 ]
 
 ROOT_URLCONF = "config.urls"
+LOGIN_URL = "/inclusion_connect/authorize"
 LOGIN_REDIRECT_URL = "/forum"
 LOGOUT_REDIRECT_URL = "/forum"
 


### PR DESCRIPTION
### Quoi ?

Ajout de la bonne URL d'authentification.

### Pourquoi ?

Lorsqu'on tente d'accéder à une page nécessitant des droits, nous sommes redirigé vers la page de login par défaut qui n'est pas implémentée.

### Comment ?

Ajout de la page d'authentification d'Inclusion Connect dans les `settings.py`.