### PR TITLE
Invitation des membres d'une communauté - étape 2 - ajout de la page de destination et le formulaire

### DIFF
--- a/lacommunaute/templates/forum_member/join_forum_form.html
+++ b/lacommunaute/templates/forum_member/join_forum_form.html
@@ -1,0 +1,64 @@
+{% extends "board_base.html" %}
+{% load i18n %}
+{% load static %}
+
+{% block sub_title %}{% trans "Join forum" %}{% endblock sub_title %}
+
+{% block breadcrumb %}
+    <section>
+        <div class="container">
+            <div class="row">
+                <div class="col-12">
+                    <nav class="c-breadcrumb c-breadcrumb--communaute" aria-label="Fil d'ariane">
+                        <ol class="breadcrumb">
+                            <li class="breadcrumb-item"><a href="{% url 'pages:home' %}">Accueil</a></li>
+                            <li class="breadcrumb-item"><a href="{% url 'forum:index' %}">{% trans "Forum index" %}</a></li>
+                            <li class="breadcrumb-item active" aria-current="page">{% trans "Join forum" %}</li>
+                        </ol>
+                    </nav>
+                </div>
+            </div>
+        </div>
+    </section>
+{% endblock %}
+
+{% block content %}
+    <section class="s-title-01">
+        <div class="s-title-01__container container">
+            <div class="s-title-01__row row">
+                <div class="s-title-01__col col-12">
+                    <h1 class="s-title-01__title h1"><strong>{% trans "Join forum" %}</strong></h1>
+                </div>
+            </div>
+        </div>
+    </section>
+
+    <section class="s-section">
+        <div class="s-section__container container">
+            <div class="s-section__row row">
+                <div class="s-section__col col-12 col-lg-7">
+                    <div class="card">
+                        <div class="c-form">
+                            <form method="post" action="." enctype="multipart/form-data" novalidate>
+                                {% csrf_token %}
+                                {% if form.non_field_errors %}
+                                    {% for error in form.non_field_errors %}
+                                        <div class="alert alert-danger">
+                                            <i class="icon-exclamation-sign"></i>
+                                            {{ error }}
+                                        </div>
+                                    {% endfor %}
+                                {% endif %}
+                                {% include "partials/form_field.html" with field=form.username %}
+                                {% include "partials/form_field.html" with field=form.password %}
+                                <div class="form-actions">
+                                    <input type="submit" class="btn btn-large btn-primary" value="{% trans "Join forum" %}" />
+                                </div>
+                            </form>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </section>
+{% endblock content %}

--- a/lacommunaute/templates/forum_member/join_forum_landing.html
+++ b/lacommunaute/templates/forum_member/join_forum_landing.html
@@ -1,0 +1,52 @@
+{% extends "board_base.html" %}
+{% load i18n %}
+{% load static %}
+
+{% block sub_title %}{% trans "Join forum" %}{% endblock sub_title %}
+
+{% block breadcrumb %}
+    <section>
+        <div class="container">
+            <div class="row">
+                <div class="col-12">
+                    <nav class="c-breadcrumb c-breadcrumb--communaute" aria-label="Fil d'ariane">
+                        <ol class="breadcrumb">
+                            <li class="breadcrumb-item"><a href="{% url 'pages:home' %}">Accueil</a></li>
+                            <li class="breadcrumb-item"><a href="{% url 'forum:index' %}">{% trans "Forum index" %}</a></li>
+                            <li class="breadcrumb-item active" aria-current="page">{% trans "Join forum" %}</li>
+                        </ol>
+                    </nav>
+                </div>
+            </div>
+        </div>
+    </section>
+{% endblock %}
+
+{% block content %}
+    <section class="s-title-01">
+        <div class="s-title-01__container container">
+            <div class="s-title-01__row row">
+                <div class="s-title-01__col col-12">
+                    <h1 class="s-title-01__title h1"><strong>{% trans "Join forum" %}</strong></h1>
+                </div>
+            </div>
+        </div>
+    </section>
+
+    <section class="s-section">
+        <div class="s-section__container container">
+            <div class="s-section__row row">
+                <div class="s-section__col col-12 col-lg-7">
+                    <div class="card">
+                        <a href="{% url 'inclusion_connect:authorize' %}" class="btn {{ button_size }} btn-ico btn-outline-primary">
+                            <i class="ri-login-box-line ri-lg"></i>
+                            <span>
+                                Se connecter avec Inclusion Connect
+                            </span>
+                        </a>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </section>
+{% endblock content %}

--- a/lacommunaute/www/forum_member/forms.py
+++ b/lacommunaute/www/forum_member/forms.py
@@ -1,0 +1,8 @@
+from django import forms
+
+
+class JoinForumForm(forms.Form):
+    invitation_token = forms.HiddenInput()
+
+    def join_forum(self):
+        pass

--- a/lacommunaute/www/forum_member/urls.py
+++ b/lacommunaute/www/forum_member/urls.py
@@ -1,10 +1,12 @@
 from django.urls import path
 
-from lacommunaute.www.forum_member.views import ForumProfileListView
+from lacommunaute.www.forum_member.views import ForumProfileListView, JoinForumFormView, JoinForumLandingView
 
 
 app_name = "members"
 
 urlpatterns = [
     path("", ForumProfileListView.as_view(), name="profiles"),
+    path("join-forum-landing/", JoinForumLandingView.as_view(), name="join_forum_landing"),
+    path("join-forum/", JoinForumFormView.as_view(), name="join_forum_form"),
 ]

--- a/lacommunaute/www/forum_member/views.py
+++ b/lacommunaute/www/forum_member/views.py
@@ -1,7 +1,11 @@
 import logging
 
-from django.views.generic import ListView
+from django.contrib.auth.mixins import LoginRequiredMixin
+from django.urls import reverse_lazy
+from django.views.generic import FormView, ListView, TemplateView
 from machina.core.db.models import get_model
+
+from lacommunaute.www.forum_member.forms import JoinForumForm
 
 
 logger = logging.getLogger(__name__)
@@ -15,3 +19,21 @@ class ForumProfileListView(ListView):
     model = ForumProfile
     template_name = "forum_member/profiles.html"
     context_object_name = "forum_profiles"
+
+
+class JoinForumLandingView(TemplateView):
+
+    template_name = "forum_member/join_forum_landing.html"
+
+
+class JoinForumFormView(LoginRequiredMixin, FormView):
+
+    login_url = reverse_lazy("members:join_forum_landing")
+    template_name = "forum_member/join_forum_form.html"
+    form_class = JoinForumForm
+
+    success_url = "/"  # TODO: set target forum URL
+
+    def form_valid(self, form):
+        form.join_forum()
+        return super().form_valid(form)


### PR DESCRIPTION
### Quoi ?

cf titre

### Pourquoi ?

Inviter les utilisateurs à devenir membre d'une communauté,

### Comment ?

Création d'une page de destination pour les utilisateurs non connecté.
Création d'un formulaire pour les utilisateurs authentifiés.
