### PR TITLE
Invitation des membres d'une communauté - Bonus - afficher le lien d'invitation pour les animateurs de la communauté

### DIFF
--- a/lacommunaute/forum/tests.py
+++ b/lacommunaute/forum/tests.py
@@ -191,6 +191,35 @@ class ForumViewTest(TestCase):
         self.assertEqual(response.status_code, 200)
         self.assertContains(response, f'<a href="{topic_url}"')
 
+    def test_join_url_is_hidden(self):
+        url = reverse("forum:forum", kwargs={"pk": self.forum.pk, "slug": self.forum.slug})
+        self.client.login(username=self.user.username, password=DEFAULT_PASSWORD)
+        response = self.client.get(url)
+        self.assertNotContains(
+            response,
+            reverse(
+                "members:join_forum_landing",
+                kwargs={
+                    "token": self.forum.invitation_token,
+                },
+            ),
+        )
+
+    def test_join_url_is_shown(self):
+        assign_perm("can_approve_posts", self.user, self.forum)
+        url = reverse("forum:forum", kwargs={"pk": self.forum.pk, "slug": self.forum.slug})
+        self.client.login(username=self.user.username, password=DEFAULT_PASSWORD)
+        response = self.client.get(url)
+        self.assertContains(
+            response,
+            reverse(
+                "members:join_forum_landing",
+                kwargs={
+                    "token": self.forum.invitation_token,
+                },
+            ),
+        )
+
 
 class ForumModelTest(TestCase):
     def test_invitation_token_is_unique(self):

--- a/lacommunaute/templates/forum/forum_detail.html
+++ b/lacommunaute/templates/forum/forum_detail.html
@@ -61,4 +61,12 @@
             </div>
         </div>
     {% endif %}
+
+    {% get_permission 'can_approve_posts' forum request.user as user_can_invite_to_forum %}
+    {% if user_can_invite_to_forum %}
+        <div class="small">Inviter des nouveaux membres en partageant ce lien :
+            {{ request.scheme }}://{{ request.META.HTTP_HOST }}{% url 'members:join_forum_landing' forum.invitation_token %}
+        </div>
+    {%endif%}
+
 {% endblock content %}


### PR DESCRIPTION
### Quoi ?

cf titre

### Pourquoi ?

pour faciliter l'obtention de l'URL sans passer par l'équipe de dev ni l'interface d'admin

### Comment ?

Vérifier les droits `can_approve_posts` de l'utilisateur et afficher l'URL en bas de page