### PR TITLE
Desactivation de BASE_TEMPLATE

### DIFF
--- a/lacommunaute/templates/board_base.html
+++ b/lacommunaute/templates/board_base.html
@@ -1,4 +1,4 @@
-{% extends BASE_TEMPLATE %}
+{% extends "layouts/base.html" %}
 {% load static %}
 {% load i18n %}
 {% load forum_permission_tags %}


### PR DESCRIPTION
ignorer BASE_TEMPLATE dans `board_base.html`
utilisation de `{% extends "layouts/base.html" %}` temporairement.