### PR TITLE
Appeler la commande 'shell_plus' dans l'alias 'make console'

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,7 @@ endif
 # --------------------------------------------------------------------------------------------------
 
 console:
-	$(EXEC_CMD) python manage.py shell
+	$(EXEC_CMD) python manage.py shell_plus
 
 migrate:
 	$(EXEC_CMD) python manage.py migrate


### PR DESCRIPTION
### Quoi ?

Mise à jour du `Makefile`, remplacement de l'appel à `shell` par l'appel à `shell_plus`
