### PR TITLE
Statistiques : prise en compte de l'arborescence des communautés

### DIFF
--- a/lacommunaute/templates/pages/statistiques.html
+++ b/lacommunaute/templates/pages/statistiques.html
@@ -38,7 +38,7 @@
                             </div>
                             <div class="card-body">
                                 <p>
-                                    <span class="badge badge-base badge-pill badge-communaute text-white">{{ forum_stats.members_count }} membre{{ forum_stats.members_count|pluralizefr }}</span>
+                                    {% if forum_stats.is_private %}<span class="badge badge-base badge-pill badge-communaute text-white">{{ forum_stats.members_count }} membre{{ forum_stats.members_count|pluralizefr }}</span>{% endif %}
                                     <span class="badge badge-base badge-pill badge-communaute text-white">{{ forum_stats.topics_count }} sujet{{ forum_stats.topics_count|pluralizefr }}</span>
                                     <span class="badge badge-base badge-pill badge-communaute text-white">{{ forum_stats.posts_count }} post{{ forum_stats.posts_count|pluralizefr }}</span>
                                 </p>
@@ -57,14 +57,18 @@
                                         label: 'Nombre de sujets',
                                         data: {{ forum_stats.stats.topics|js }},
                                     },
-                                        {
-                                            label: 'Nombre de posts',
-                                            data: {{ forum_stats.stats.posts|js }},
-                                        },
-                                        {
-                                            label: 'Nombre de membres',
-                                            data: {{ forum_stats.stats.members|js }},
-                                        }]
+                                    {
+                                        label: 'Nombre de posts',
+                                        data: {{ forum_stats.stats.posts|js }},
+                                    }
+                                    {% if forum_stats.is_private %}
+                                    ,
+                                    {
+                                        label: 'Nombre de membres',
+                                        data: {{ forum_stats.stats.members|js }},
+                                    }
+                                    {% endif %}
+                                    ]
                                 },
                                 options: {
                                     scales: {

--- a/lacommunaute/www/pages/views.py
+++ b/lacommunaute/www/pages/views.py
@@ -37,6 +37,7 @@ def statistiques(request):
         stats = node.obj.get_stats(7)
         forum_stats = {
             "name": node.obj.name,
+            "is_private": node.obj.is_private,  # add this because members counters make sense only if forum is private
             "posts_count": node.posts_count,
             "topics_count": node.topics_count,
             "members_count": stats["members"][-1],


### PR DESCRIPTION
### Quoi ?

cf titre

### Pourquoi ?

Les statistiques des communautés ne prennent pas en compte les statistiques des enfants.

### Comment ?

Ajout des pk des enfants dans le filtre des sujets, des posts et des membres
Le nombre de membres est également masqué pour les communautés publiques car il n'y a pas d'adhésion dans ce cas. 

