### PR TITLE
Requêtes dupliquées dans la vue ForumView

### DIFF
--- a/lacommunaute/forum/views.py
+++ b/lacommunaute/forum/views.py
@@ -35,7 +35,7 @@ class ForumView(BaseForumView):
             .exclude(topic__approved=False)
             .filter(Q(id__in=Subquery(newest_sq)) | Q(id__in=Subquery(latest_sq)))
             .order_by("topic", "created")
-            .select_related("poster", "poster__forum_profile")
+            .select_related("poster", "poster__forum_profile", "updated_by")
             .prefetch_related("attachments")
         )
         return (


### PR DESCRIPTION
## Description

🎸 Ajout du champ `updated_by` dans le `select_related` des `Posts` de la méthode `get_queryset` de `ForumView`

## Type de changement

🪲 Correction de bug

### Points d'attention

🦺 duplicated or very similar queries still exist