### PR TITLE
Page statistique : les sujets de type annonces doivent être compte

### DIFF
--- a/lacommunaute/forum/models.py
+++ b/lacommunaute/forum/models.py
@@ -56,7 +56,6 @@ class Forum(AbstractForum):
                     approved=True,
                     created__lte=day,
                 )
-                .exclude(topic__type=Topic.TOPIC_ANNOUNCE)
                 .exclude(topic__approved=False)
                 .values("topic__approved")  # group by unique value to group forum and its children
                 .annotate(count=Count("pk"))


### PR DESCRIPTION
## Description

🎸 les annonces doivent être prise en compte pour que la courbe corresponde aux compteurs de machina.

## Type de changement

🪲 Suppression de l'exclude pour la prise en compte des annonces
