### PR TITLE
Stats : Ajout des évènements Matomo

### DIFF
--- a/lacommunaute/static/javascripts/matomo.js
+++ b/lacommunaute/static/javascripts/matomo.js
@@ -1,0 +1,16 @@
+/********************************************************************
+     Send an event to Matomo on click.
+    Usage:
+    <a href="#" class="matomo-event" data-matomo-category="MyCategory"
+    data-matomo-action="MyAction" data-matomo-option="MyOption" >
+********************************************************************/
+document.addEventListener("matomo_loaded", (e) => {
+    if (window._paq !== undefined) {
+        $(".matomo-event").on("click", function () {
+            var category = $(this).data("matomo-category");
+            var action = $(this).data("matomo-action");
+            var option = $(this).data("matomo-option");
+            window._paq.push(['trackEvent', category, action, option]);
+        });
+    }
+}, false);

--- a/lacommunaute/templates/forum_conversation/partials/topic_likes.html
+++ b/lacommunaute/templates/forum_conversation/partials/topic_likes.html
@@ -5,7 +5,9 @@
         {% if user.is_authenticated %}
             <button hx-post="{% url 'forum_conversation_extension:like_topic' topic.forum.slug topic.forum.pk topic.slug topic.pk %}" id="like-button{{topic.pk}}"
                 hx-target="#likesarea{{topic.pk}}"
-                hx-swap="outerHTML" class="btn btn-link btn-sm btn-ico pr-0">
+                hx-swap="outerHTML" class="btn btn-link btn-sm btn-ico pr-0 matomo-event"
+                data-matomo-category="engagement" data-matomo-action="like" data-matomo-option="{% if topic.has_liked %}unlike{%else%}like{%endif%}"
+                >
                 <i class="{% if topic.has_liked %}fas{%else%}far{%endif%} fa-heart mr-2 text-danger"></i>
                 <span>{{counter}} like{{ counter|pluralizefr }}</span>
             </button>

--- a/lacommunaute/templates/layouts/base.html
+++ b/lacommunaute/templates/layouts/base.html
@@ -148,6 +148,9 @@
                     (tarteaucitron.job = tarteaucitron.job || []).push('matomo');
                 {% endif %}
             </script>
+            {% if COMMU_ENVIRONMENT == 'PROD' %}
+                <script type="text/javascript" src="{% static 'javascripts/matomo.js' %}" defer></script>
+            {% endif %}
             <script type="text/javascript" src="{% static 'vendor/htmx-1.8.4/htmx.min.js' %}" defer></script>
         {% endblock %}
     </body>


### PR DESCRIPTION
## Description

🎸 Ajout du suivi des évènements Matomo pour mieux suivre les comportements utilisateurs, notamment sur le like.

## Type de changement

🎢 Ajout de l'envoi des évènements
🎢 Ajout des attributs Matomo sur le bouton like
