### PR TITLE
Corrections rapides

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -12,7 +12,7 @@
 
 ### Points d'attention
 
-🦺 Décision d'architure
+🦺 Décision d'architecture
 🦺 Lien avec d'autres PR
 🦺 Code sensible
 

--- a/README.md
+++ b/README.md
@@ -155,9 +155,9 @@ name = 'nom du forum privé'
 ```
 
 ```
-forum, _ = Forum.objects.get_or_create(name=name,type=0)
 moderators, _ = Group.objects.get_or_create(name=f"{name} moderators")
 members, _ = Group.objects.get_or_create(name=f"{name} members")
+forum, _ = Forum.objects.get_or_create(name=name,private=True,members_group=members,type=0)
 ```
 
 ### ajouter les droits pour les utilisateurs anonymes

--- a/lacommunaute/forum/tests.py
+++ b/lacommunaute/forum/tests.py
@@ -226,7 +226,7 @@ class ForumViewTest(TestCase):
         self.assertNotContains(
             response,
             reverse(
-                "members:join_forum_landing",
+                "members:join_forum_form",
                 kwargs={
                     "token": self.forum.invitation_token,
                 },
@@ -240,7 +240,7 @@ class ForumViewTest(TestCase):
         self.assertContains(
             response,
             reverse(
-                "members:join_forum_landing",
+                "members:join_forum_form",
                 kwargs={
                     "token": self.forum.invitation_token,
                 },

--- a/lacommunaute/templates/forum/forum_detail.html
+++ b/lacommunaute/templates/forum/forum_detail.html
@@ -68,7 +68,7 @@
     {% get_permission 'can_approve_posts' forum request.user as user_can_invite_to_forum %}
     {% if user_can_invite_to_forum %}
         <hr>
-        <p class="fs-lg">Inviter des nouveaux membres en partageant ce lien : <br><strong>{{ request.scheme }}://{{ request.META.HTTP_HOST }}{% url 'members:join_forum_landing' forum.invitation_token %}</strong></p>
+        <p class="fs-lg">Inviter des nouveaux membres en partageant ce lien : <br><strong>{{ request.scheme }}://{{ request.META.HTTP_HOST }}{% url 'members:join_forum_form' forum.invitation_token %}</strong></p>
     {%endif%}
 
 {% endblock content %}


### PR DESCRIPTION
## Description

🎸 Corrections rapides à droite à gauche

## Type de changement

🪲 Correction du lien d'invitation à rejoindre une communauté privée
🪲 Correction d'une petite faute dans le template de PR
🪲 Petite modification de la procédure de création d'une communauté privée pour qu'elle soit directement en privée et attachée au bon groupe de membres

### Points d'attention

🦺 Le lien d'invitation doit impérativement pointer vers le formulaire pour rejoindre la communauté, ainsi, si la personne n'ai pas connectée, elle est redirigée vers la landing avec la bonne URL de retour. Si elle est connectée, elle peut directement rejoindre la communauté. À mon avis, ce lien a été oublié quand on a mis en place l'URL de retour et pose désormais problème.
