### PR TITLE
Masquer la description de la communauté si elle est vide

### DIFF
--- a/lacommunaute/templates/forum/forum_detail.html
+++ b/lacommunaute/templates/forum/forum_detail.html
@@ -12,7 +12,9 @@
     <div class="row">
         <div class="col-12">
             <h1 class="mb-1">{{ forum.name }}</h1>
-            <p class="lead">{{forum.description}}</small>
+            {%if forum.description %}
+                <p class="lead">{{forum.description}}</small>
+            {%endif%}
         </div>
     </div>
     {% if sub_forums %}


### PR DESCRIPTION
## Description

🎸 Masquer la description de la communauté dans la page `forum_detail` si la description n'est pas renseignée

## Type de changement

🪲 Correction de bug (changement non cassant qui corrige un problème).

### Points d'attention

🦺 pas de test, assumé
