### PR TITLE
Masquer les informations d'édition des Topic et des Post

### DIFF
--- a/lacommunaute/templates/forum_conversation/topic_detail.html
+++ b/lacommunaute/templates/forum_conversation/topic_detail.html
@@ -68,19 +68,7 @@
                                         {{ post.poster.forum_profile.signature.rendered }}
                                     </div>
                                 {% endif %}
-                                {% if post.updates_count %}
-                                    <div class="mt-4 edit-info">
-                                        <small class="text-muted">
-                                            <i class="fas fa-edit"></i>&nbsp;{% if post.updated_by %}{% trans "Last edited by:" %}&nbsp;<a href="{% url 'forum_member:profile' post.updated_by_id %}">{{ post.updated_by|forum_member_display_name }}</a>&nbsp;{% else %}{% trans "Updated" %}&nbsp;{% endif %}{% trans "on" %}&nbsp;{{ post.updated }}, {% blocktrans count counter=post.updates_count %}edited {{counter }} time in total.{% plural %}edited {{counter }} times in total.{% endblocktrans %}
-                                        </small>
-                                        {% if post.update_reason %}
-                                            <br />
-                                            <small class="text-muted">
-                                                <b>{% trans "Reason:" %}</b>&nbsp;{{ post.update_reason }}
-                                            </small>
-                                        {% endif %}
-                                    </div>
-                                {% endif %}
+
                             </div>
                         </div>
                     </div>

--- a/lacommunaute/templates/forum_conversation/topic_list.html
+++ b/lacommunaute/templates/forum_conversation/topic_list.html
@@ -81,19 +81,7 @@
                                                                     {{ post.poster.forum_profile.signature.rendered }}
                                                                 </div>
                                                             {% endif %}
-                                                            {% if post.updates_count %}
-                                                                <div class="mt-4 edit-info">
-                                                                    <small class="text-muted">
-                                                                        <i class="fas fa-edit"></i>&nbsp;{% if post.updated_by %}{% trans "Last edited by:" %}&nbsp;<a href="{% url 'forum_member:profile' post.updated_by_id %}">{{ post.updated_by|forum_member_display_name }}</a>&nbsp;{% else %}{% trans "Updated" %}&nbsp;{% endif %}{% trans "on" %}&nbsp;{{ post.updated }}, {% blocktrans count counter=post.updates_count %}edited {{counter }} time in total.{% plural %}edited {{counter }} times in total.{% endblocktrans %}
-                                                                    </small>
-                                                                    {% if post.update_reason %}
-                                                                        <br />
-                                                                        <small class="text-muted">
-                                                                            <b>{% trans "Reason:" %}</b>&nbsp;{{ post.update_reason }}
-                                                                        </small>
-                                                                    {% endif %}
-                                                                </div>
-                                                            {% endif %}
+
                                                         </div>
                                                     </div>
                                                 </div>


### PR DESCRIPTION
## Description

🎸 Les infos d'édition des `Post` et des `Topic` surchargent l'UI sans apporter de réelle valeur. Elles sont masquées dans la vue `forum_detail` et `topic_detail`. 

![image](https://user-images.githubusercontent.com/11419273/205643278-2ec60e88-fbdc-4008-b59e-1d37d252d0fc.png)

## Type de changement

🎢 Nouvelle fonctionnalité (changement non cassant qui ajoute une fonctionnalité).

### Points d'attention

🦺 ces informations pourront être remises à disposition des animateurs ultérieurement


### Captures d'écran (optionnel)

![image](https://user-images.githubusercontent.com/11419273/205643709-18f96a01-f76d-44ad-8af1-2632ad17a76a.png)
