### PR TITLE
Masquer le lien vers les images dans les pièces jointes des posts

### DIFF
--- a/lacommunaute/templates/forum_conversation/forum_attachments/attachments_detail.html
+++ b/lacommunaute/templates/forum_conversation/forum_attachments/attachments_detail.html
@@ -5,10 +5,12 @@
 {% get_permission 'can_download_files' post.topic.forum request.user as user_can_download_files %}
 {% if post.attachments.exists and user_can_download_files %}
     <div class="row attachments mt-3 mt-md-5">
+        {% comment %}
         <div class="col-md-12">
             <hr />
             <p class="h5 mb-0">{% trans "Attachments" %}</p>
         </div>
+        {% endcomment %}
         {% for attachment in post.attachments.all %}
             {% if not attachment|is_image %}
                 <div class="col-md-12 attachment">

--- a/lacommunaute/templates/forum_conversation/forum_attachments/attachments_detail.html
+++ b/lacommunaute/templates/forum_conversation/forum_attachments/attachments_detail.html
@@ -1,5 +1,6 @@
 {% load i18n %}
 {% load forum_permission_tags %}
+{% load attachments_tags %}
 
 {% get_permission 'can_download_files' post.topic.forum request.user as user_can_download_files %}
 {% if post.attachments.exists and user_can_download_files %}
@@ -9,12 +10,14 @@
             <p class="h5 mb-0">{% trans "Attachments" %}</p>
         </div>
         {% for attachment in post.attachments.all %}
-            <div class="col-md-12 attachment">
-                <a href="{% url 'forum_conversation:attachment' pk=attachment.id %}"><i class="fa fa-file"></i>&nbsp;{{ attachment.filename }} ({{ attachment.file.size|filesizeformat }})</a>
-                {% if attachment.comment %}
-                    <p class="text-muted"><em>{{ attachment.comment }}</em></p>
-                {% endif %}
-            </div>
+            {% if not attachment|is_image %}
+                <div class="col-md-12 attachment">
+                    <a href="{% url 'forum_conversation:attachment' pk=attachment.id %}"><i class="fa fa-file"></i>&nbsp;{{ attachment.filename }} ({{ attachment.file.size|filesizeformat }})</a>
+                    {% if attachment.comment %}
+                        <p class="text-muted"><em>{{ attachment.comment }}</em></p>
+                    {% endif %}
+                </div>
+            {%endif%}
         {% endfor %}
     </div>
 {% endif %}


### PR DESCRIPTION
## Description

🎸 Les pièces jointes de type image sont affichées dans le texte du message. Ne plus faire apparaitre le lien dans la liste des pièces jointes

## Type de changement

🎢 Nouvelle fonctionnalité (changement non cassant qui ajoute une fonctionnalité).

### Points d'attention

🦺 Le titre "Pièces jointes" et sa ligne de séparation sont mis en commentaires le temps de trouver une solution simple pour :
- les afficher quand il y a des pièces jointes de type autre que image
- ne pas les afficher quand les pièces jointes sont toutes de type image

### Captures d'écran (optionnel)

![image](https://user-images.githubusercontent.com/11419273/205887770-c82b8445-080b-4f0f-a05d-38f4b6af1ae4.png)

