### PR TITLE
Rediriger l'utilisateur vers sa page de profil après la mise à jour de son profil

### DIFF
--- a/lacommunaute/templates/forum_conversation/partials/poster.html
+++ b/lacommunaute/templates/forum_conversation/partials/poster.html
@@ -7,7 +7,7 @@
     {% spaceless %}
         <i class="fas fa-clock"></i>&nbsp;
         {% if post.poster %}
-            {% url 'forum_member:profile' post.poster_id as poster_url %}
+            {% url 'members:profile' post.poster_id as poster_url %}
             {% blocktrans trimmed with poster_url=poster_url username=post.poster|forum_member_display_name creation_date=post.created %}
                 By: <a href="{{ poster_url }}">{{ username }}</a> on {{ creation_date }}
             {% endblocktrans %}

--- a/lacommunaute/templates/forum_member/forum_profile_detail.html
+++ b/lacommunaute/templates/forum_member/forum_profile_detail.html
@@ -20,40 +20,16 @@
                     <div class="profile-username">
                         <h3 class="my-3 text-center text-muted">{{ profile.user|forum_member_display_name }}</h3>
                     </div>
-                </div>
-            </div>
-            {% if profile.user == request.user %}
-                <a href="{%url 'forum_member:profile_update' %}" class="btn btn-block btn-primary">{% trans "Edit profile" %}</a>
-            {% endif %}
-        </div>
-        <div class="col-md-9">
-            <div class="mb-3 row">
-                <div class="col-md-12">
-                    <div class="profile-content">
-                        <div class="card">
-                            <div class="card-header">{% trans "Statistics" %}</div>
-                            <div class="card-body">
-                                <div class="row">
-                                    <div class="col-md-12 divider text-center">
-                                        <div class="row">
-                                            <div class="col-12 col-sm-6 emphasis">
-                                                {% blocktrans count counter=profile.posts_count %}<h2><strong>{{ counter }}</strong></h2>
-                                                    <p><small>Post</small></p>{% plural %}<h2><strong>{{ counter }}</strong></h2>
-                                                    <p class="mb-1"><small>Posts</small></p>{% endblocktrans %}
-                                            </div>
-                                            <div class="col-12 col-sm-6 emphasis">
-                                                {% blocktrans count counter=topics_count %}<h2><strong>{{ counter }}</strong></h2>
-                                                    <p><small>Topic</small></p>{% plural %}<h2><strong>{{ counter }}</strong></h2>
-                                                    <p class="mb-1"><small>Topics</small></p>{% endblocktrans %}
-                                            </div>
-                                        </div>
-                                    </div>
-                                </div>
-                            </div>
-                        </div>
+                    <div class="profile-signature">
+                        <p class="my-3 text-center text-muted">{{ profile.signature }}</p>
                     </div>
                 </div>
             </div>
+            {% if profile.user == request.user %}
+                <a href="{%url 'members:profile_update' %}" class="btn btn-block btn-primary">{% trans "Edit profile" %}</a>
+            {% endif %}
+        </div>
+        <div class="col-md-9">
             <div class="row recent-posts">
                 <div class="col-md-12">
                     <div class="card">

--- a/lacommunaute/templates/forum_member/forum_profile_detail.html
+++ b/lacommunaute/templates/forum_member/forum_profile_detail.html
@@ -39,7 +39,7 @@
                                 <div class="row post">
                                     <div class="col-md-12 post-content-wrapper">
                                         <div class="post-title">
-                                            <a href="{% url 'forum_conversation:topic' post.topic.forum.slug post.topic.forum.pk post.topic.slug post.topic.pk %}?post={{ post.pk }}#{{ post.pk }}">{{ post.subject }}</a>
+                                            <a href="{% url 'forum_conversation:topic' post.topic.forum.slug post.topic.forum.pk post.topic.slug post.topic.pk %}?post={{ post.pk }}#{{ post.pk }}">{{ post.topic.subject }}</a>
                                         </div>
                                         <p>
                                             <small class="text-muted">

--- a/lacommunaute/templates/partials/header_nav_primary_items.html
+++ b/lacommunaute/templates/partials/header_nav_primary_items.html
@@ -28,7 +28,7 @@
                         <div class="dropdown-divider"></div>
                     </li>
                     <li>
-                        <a class="dropdown-item text-primary" href="{% url 'forum_member:profile_update' %}">Modifier mon profil</a>
+                        <a class="dropdown-item text-primary" href="{% url 'members:profile' user.id %}">Accéder à mon profil</a>
                     </li>
                     {% if user.is_superuser %}
                         <li>

--- a/lacommunaute/www/forum_member/tests.py
+++ b/lacommunaute/www/forum_member/tests.py
@@ -1,7 +1,7 @@
 import uuid
 
 from django.contrib.auth.models import Group
-from django.test import TestCase
+from django.test import RequestFactory, TestCase
 from django.urls import reverse
 from machina.core.loading import get_class
 from machina.test.factories.forum import create_forum
@@ -9,10 +9,20 @@ from machina.test.factories.forum import create_forum
 from lacommunaute.forum_member.factories import ForumProfileFactory
 from lacommunaute.forum_member.models import ForumProfile
 from lacommunaute.users.factories import DEFAULT_PASSWORD, UserFactory
+from lacommunaute.www.forum_member.views import ForumProfileUpdateView
 
 
 PermissionHandler = get_class("forum_permission.handler", "PermissionHandler")
 assign_perm = get_class("forum_permission.shortcuts", "assign_perm")
+
+
+class ForumProfileUpdateViewTest(TestCase):
+    def test_success_url(self):
+        forum_profiles = ForumProfileFactory()
+        view = ForumProfileUpdateView()
+        view.request = RequestFactory().get("/")
+        view.request.user = forum_profiles.user
+        self.assertEqual(view.get_success_url(), reverse("members:profile", kwargs={"pk": forum_profiles.user.pk}))
 
 
 class ForumProfileListViewTest(TestCase):

--- a/lacommunaute/www/forum_member/urls.py
+++ b/lacommunaute/www/forum_member/urls.py
@@ -1,7 +1,9 @@
 from django.urls import path
 
 from lacommunaute.www.forum_member.views import (
+    ForumProfileDetailView,
     ForumProfileListView,
+    ForumProfileUpdateView,
     JoinForumFormView,
     JoinForumLandingView,
     ModeratorProfileListView,
@@ -12,6 +14,8 @@ app_name = "members"
 
 urlpatterns = [
     path("", ForumProfileListView.as_view(), name="profiles"),
+    path("profile/edit/", ForumProfileUpdateView.as_view(), name="profile_update"),
+    path("profile/<str:pk>/", ForumProfileDetailView.as_view(), name="profile"),
     path("forum/<str:slug>-<int:pk>/", ModeratorProfileListView.as_view(), name="forum_profiles"),
     path("join-forum-landing/<uuid:token>/", JoinForumLandingView.as_view(), name="join_forum_landing"),
     path("join-forum/<uuid:token>/", JoinForumFormView.as_view(), name="join_forum_form"),

--- a/lacommunaute/www/forum_member/views.py
+++ b/lacommunaute/www/forum_member/views.py
@@ -9,9 +9,10 @@ from machina.apps.forum_member.views import (
     ForumProfileDetailView as BaseForumProfileDetailView,
     ForumProfileUpdateView as BaseForumProfileUpdateView,
 )
-from machina.core.db.models import get_model
 from machina.core.loading import get_class
 
+from lacommunaute.forum.models import Forum
+from lacommunaute.forum_member.models import ForumProfile
 from lacommunaute.utils.urls import get_safe_url
 from lacommunaute.www.forum_member.forms import JoinForumForm
 
@@ -19,8 +20,6 @@ from lacommunaute.www.forum_member.forms import JoinForumForm
 logger = logging.getLogger(__name__)
 
 
-ForumProfile = get_model("forum_member", "ForumProfile")
-Forum = get_model("forum", "Forum")
 PermissionRequiredMixin = get_class("forum_permission.viewmixins", "PermissionRequiredMixin")
 
 

--- a/lacommunaute/www/forum_member/views.py
+++ b/lacommunaute/www/forum_member/views.py
@@ -5,6 +5,10 @@ from django.shortcuts import get_object_or_404
 from django.urls import reverse
 from django.utils.http import urlencode
 from django.views.generic import FormView, ListView, TemplateView
+from machina.apps.forum_member.views import (
+    ForumProfileDetailView as BaseForumProfileDetailView,
+    ForumProfileUpdateView as BaseForumProfileUpdateView,
+)
 from machina.core.db.models import get_model
 from machina.core.loading import get_class
 
@@ -18,6 +22,15 @@ logger = logging.getLogger(__name__)
 ForumProfile = get_model("forum_member", "ForumProfile")
 Forum = get_model("forum", "Forum")
 PermissionRequiredMixin = get_class("forum_permission.viewmixins", "PermissionRequiredMixin")
+
+
+class ForumProfileDetailView(BaseForumProfileDetailView):
+    pass
+
+
+class ForumProfileUpdateView(BaseForumProfileUpdateView):
+    def get_success_url(self):
+        return reverse("members:profile", kwargs={"pk": self.request.user.pk})
 
 
 class ForumProfileListView(ListView):


### PR DESCRIPTION
## Description

🎸 Donner accès à la page de profil de l'utilisateur connecté
🎸 Lui permettre de mettre à jour son profil avec une photo et une signature
🎸 Mettre à jour les liens de navigation

## Type de changement

🎢 Nouvelle fonctionnalité (changement non cassant qui ajoute une fonctionnalité).

### Points d'attention

🦺 Surcharge des vues et des urls machina d'origine pour `ForumProfileDetailView` et `ForumProfileUpdateView`

### Captures d'écran (optionnel)

Mise à jour du lien dans le menu utilisateur

![image](https://user-images.githubusercontent.com/11419273/209972742-4ebc7875-e18f-48c7-94ce-c15ce334d60a.png)

Simplification de la page de profile

![image](https://user-images.githubusercontent.com/11419273/209973930-04bf188c-6658-4afd-96de-7ee11f807333.png)

