### PR TITLE
Integration Continue : Generation du Journal des Changements

### DIFF
--- a/.github/workflows/changelog-generator.yml
+++ b/.github/workflows/changelog-generator.yml
@@ -1,0 +1,13 @@
+name: Changelog
+on:
+  release:
+    types:
+      - created
+jobs:
+  changelog:
+    runs-on: ubuntu-20.04
+    steps:
+      - name: "✏️ Generate release changelog"
+        uses: heinrichreimer/github-changelog-generator-action@v2.3
+        with:
+          token: ${{ secrets.CHANGELOG_GITHUB_TOKEN }}


### PR DESCRIPTION
## Description

🎸 Generation automatique du journal des changements lors de la création d'une nouvelle release github

## Type de changement

🥁 Changement de rupture (modification ou caractéristique qui empêcherait une fonctionnalité existante de fonctionner comme prévu)
🎨 changement nécessitant une mise à jour de la documentation.

### Points d'attention

🦺 Ajout la clé `CHANGELOG_GITHUB_TOKEN` dans les secrets du repo.

🦺 POUR TEST