### PR TITLE
Convertir automatiquement les url dans les descriptions des communautés et dans les posts

### DIFF
--- a/lacommunaute/templates/forum/forum_detail.html
+++ b/lacommunaute/templates/forum/forum_detail.html
@@ -5,6 +5,7 @@
 {% load forum_conversation_tags %}
 {% load forum_permission_tags %}
 {% load forum_tracking_tags %}
+{% load str_filters %}
 
 {% block sub_title %}{{ forum.name }}{% endblock sub_title %}
 {% block meta_description %}{{forum.description}}{% endblock meta_description %}"
@@ -14,7 +15,7 @@
         <div class="col-12">
             <h1 class="mb-1">{{ forum.name }}</h1>
             {%if forum.description %}
-                <p class="lead">{{forum.description}}</small>
+                <p class="lead">{{forum.description|urlizetrunc_target_blank:30}}</small>
             {%endif%}
         </div>
     </div>

--- a/lacommunaute/templates/forum/forum_list.html
+++ b/lacommunaute/templates/forum/forum_list.html
@@ -4,6 +4,7 @@
 {% load forum_conversation_tags %}
 {% load forum_member_tags %}
 {% load forum_tracking_tags %}
+{% load str_filters %}
 
 <div class="row mb-3 mb-md-5">
     <div class="col-12">
@@ -64,7 +65,7 @@
                                             {% endif %}
                                             <td class="align-top">
                                                 <a href="{% url 'forum:forum' node.obj.slug node.obj.id %}" class="forum-name-link h4 d-block mb-1">{{ node.obj.name }}</a>
-                                                <div class="fs-sm lh-sm">{{ node.obj.description.rendered }}</div>
+                                                <div class="fs-sm lh-sm">{{ node.obj.description.rendered|urlizetrunc_target_blank:30 }}</div>
                                                 <div class="sub-forums"><p class="fs-sm mb-0">{{ children }}</p></div>
                                             </td>
                                         </tr>

--- a/lacommunaute/templates/forum_conversation/partials/post_feed.html
+++ b/lacommunaute/templates/forum_conversation/partials/post_feed.html
@@ -2,6 +2,7 @@
 
 {% load forum_member_tags %}
 {% load forum_permission_tags %}
+{% load str_filters %}
 
 <div class="card post my-3 bg-light has-links-inside ml-3">
     <div class="card-body">
@@ -14,7 +15,7 @@
                     {% include "forum_conversation/partials/post_upvotes.html"%}
                 </div>
                 <div class="post-content">
-                    {{ post.content.rendered|urlize }}
+                    {{ post.content.rendered|urlizetrunc_target_blank:30}}
                     {% include "forum_conversation/forum_attachments/attachments_images.html" %}
                 </div>
 

--- a/lacommunaute/templates/forum_conversation/partials/posts_list.html
+++ b/lacommunaute/templates/forum_conversation/partials/posts_list.html
@@ -2,6 +2,7 @@
 
 {% load forum_member_tags %}
 {% load forum_permission_tags %}
+{% load str_filters %}
 
 <div id="showmorepostsarea{{topic.pk}}">
     {% for post in posts %}
@@ -16,7 +17,7 @@
                             {% include "forum_conversation/partials/post_upvotes.html"%}
                         </div>
                         <div class="post-content">
-                            {{ post.content.rendered|urlize }}
+                            {{ post.content.rendered|urlizetrunc_target_blank:30}}
                             {% include "forum_conversation/forum_attachments/attachments_images.html" %}
                         </div>
 

--- a/lacommunaute/templates/forum_conversation/partials/topic_content.html
+++ b/lacommunaute/templates/forum_conversation/partials/topic_content.html
@@ -1,1 +1,3 @@
-{{topic.first_post.content.rendered|urlize}}
+{% load str_filters %}
+
+{{topic.first_post.content.rendered|urlizetrunc_target_blank:30}}

--- a/lacommunaute/templates/forum_conversation/post_preview.html
+++ b/lacommunaute/templates/forum_conversation/post_preview.html
@@ -1,5 +1,6 @@
 {% load i18n %}
 {% load forum_markup_tags %}
+{% load str_filters %}
 
 <div class="mb-3 row preview">
     <div class="col-12">
@@ -13,7 +14,7 @@
                             {% if post_form.subject.value %}
                                 <p class="font-weight-bold">{{ post_form.subject.value }}</p>
                             {% endif %}
-                            {{ post_form.content.value|safe|rendered|urlize }}
+                            {{ post_form.content.value|safe|rendered|urlizetrunc_target_blank:30}}
                         </div>
                         {% include "forum_conversation/forum_attachments/attachments_preview.html" %}
                     </div>

--- a/lacommunaute/templates/forum_conversation/topic_detail.html
+++ b/lacommunaute/templates/forum_conversation/topic_detail.html
@@ -1,6 +1,7 @@
 {% extends 'board_base.html' %}
 {% load i18n %}
 {% load forum_conversation_tags %}
+{% load str_filters %}
 
 {% block sub_title %}{{ topic.subject }}{% endblock sub_title %}
 
@@ -37,7 +38,7 @@
                                     </div>
                                 {%endif%}
                                 <div class="post-content">
-                                    {{ post.content.rendered|urlize }}
+                                    {{ post.content.rendered|urlizetrunc_target_blank:30}}
                                     {% include "forum_conversation/forum_attachments/attachments_images.html" %}
                                 </div>
 

--- a/lacommunaute/utils/templatetags/str_filters.py
+++ b/lacommunaute/utils/templatetags/str_filters.py
@@ -2,8 +2,11 @@
 https://docs.djangoproject.com/en/dev/howto/custom-template-tags/
 """
 from django import template
+from django.template.defaultfilters import stringfilter
 from django.urls import reverse
+from django.utils.html import urlize as _urlize
 from django.utils.http import urlencode
+from django.utils.safestring import mark_safe
 
 
 register = template.Library()
@@ -33,3 +36,16 @@ def inclusion_connect_url(next_url, anchor=None):
         next_url = f"{next_url}#{anchor}"
     params = {"next_url": next_url}
     return f"{reverse('inclusion_connect:authorize')}?{urlencode(params)}"
+
+
+@register.filter(is_safe=True, needs_autoescape=True)
+@stringfilter
+def urlizetrunc_target_blank(value, limit, autoescape=True):
+    """
+    Convert URLs into clickable links, truncating URLs to the given character
+    limit, and adding 'rel=nofollow' attribute to discourage spamming.
+
+    Argument: Length to truncate URLs to.
+    """
+    urlized = _urlize(value, trim_url_limit=int(limit), nofollow=True, autoescape=autoescape)
+    return mark_safe(urlized.replace("<a ", '<a target="_blank" '))

--- a/lacommunaute/utils/tests.py
+++ b/lacommunaute/utils/tests.py
@@ -116,3 +116,10 @@ class UtilsTemplateTagsTestCase(TestCase):
         d = datetime.now() - timedelta(days=10)
         out = template.render(Context({"date": d}))
         self.assertEqual(out, f"le {date(d)}, {time(d)}")
+
+    def test_urlizetrunc_target_blank(self):
+        template = Template("{% load str_filters %}{{ url|urlizetrunc_target_blank:16 }}")
+        out = template.render(Context({"url": "www.neuralia.co/mission"}))
+        self.assertEqual(
+            out, '<a target="_blank" href="http://www.neuralia.co/mission" rel="nofollow">www.neuralia.co…</a>'
+        )


### PR DESCRIPTION
## Description

🎸 Convertir automatiquement les url en liens actionnables dans les descriptions des communautés
🎸 Convertir automatiquement les url en liens actionnables dans les contenus des posts
🎸 Les liens sont raccourcis à 30 charactères, et emporte un `target=_blank` pour forcer leur ouverture dans une nouvelle fenetre.

## Type de changement

🪲 Correction de bug (changement non cassant qui corrige un problème).

### Captures d'écran (optionnel)

Fil d'actualités d'une communauté

![image](https://user-images.githubusercontent.com/11419273/210332779-08cffae1-e06c-473e-8561-71d1073d05d5.png)

Liste des communautés / sous-communautés

![image](https://user-images.githubusercontent.com/11419273/210332899-f4276d70-cb04-4c4c-9c00-82fa5f02eaed.png)
