### PR TITLE
Correction de la mise en forme de l'avatar topic-thumbnail

### DIFF
--- a/lacommunaute/static/stylesheets/itou_communaute.scss
+++ b/lacommunaute/static/stylesheets/itou_communaute.scss
@@ -38,12 +38,21 @@ body {
 .card.topiclist .card-body {
 
   .topic-thumbnail {
+    display: flex;
+    align-items: end;
+    justify-content: center;
     width: 42px;
     height: 42px;
-    text-align: center;
     margin-right: 0.50rem;
     border-radius: 50%;
-    padding-top: 0.25rem;
+    overflow: hidden;
+
+    >img {
+      width: 100%;
+      height: auto;
+      object-fit: cover;
+      aspect-ratio: 1 / 1;
+    }
   }
 
   .topic-icon {

--- a/lacommunaute/templates/forum/forum_detail.html
+++ b/lacommunaute/templates/forum/forum_detail.html
@@ -23,7 +23,7 @@
         {% forum_list sub_forums %}
     {% endif %}
     {% if forum.is_forum %}
-        <div class="mt-4 row justify-content-between">
+        <div class="row justify-content-between mt-4">
             {% get_permission 'can_add_topic' forum request.user as user_can_add_topic %}
             {% get_permission 'can_approve_posts' forum request.user as user_can_access_stats %}
             {% if user_can_add_topic or user_can_access_stats %}
@@ -57,7 +57,7 @@
         {% with topic_list_title=topics_title_trans unread_topics=unread_topics%}
             {% include "forum_conversation/topic_list.html" %} <!-- note vincentporte : to be optimized -->
         {% endwith %}
-        <div class="mt-5 mb-5 row">
+        <div class="row mt-5 mb-5">
             <div class="col-12">
                 {% with "justify-content-center" as pagination_size %}
                     {% include "partials/pagination.html" %}

--- a/lacommunaute/templates/forum_conversation/topic_list.html
+++ b/lacommunaute/templates/forum_conversation/topic_list.html
@@ -25,7 +25,7 @@
                                     <div class="card-header d-flex align-items-center mb-1">
                                         <div class="topic-thumbnail bg-light">
                                             {% if topic.poster.forum_profile.avatar %}
-                                                <img class="img-thumbnail" src="{{ topic.poster.forum_profile.avatar.url }}" alt="{{ topic.poster.forum_profile.user.get_full_name }}">
+                                                <img src="{{ topic.poster.forum_profile.avatar.url }}" alt="{{ topic.poster.forum_profile.user.get_full_name }}" />
                                             {% else %}
                                                 <i class="ri-user-line ri-2x"></i>
                                             {% endif %}

--- a/lacommunaute/templates/forum_member/moderator_profiles.html
+++ b/lacommunaute/templates/forum_member/moderator_profiles.html
@@ -29,19 +29,18 @@
                                     </h3>
                                 </div>
                             </div>
-
                         {% empty %}
                             <p>No body yet…</p>
                         {% endfor %}
                     </div>
-                    <div class="mt-5 mb-5 row">
+                    <div class="row mt-5 mb-5">
                         <div class="col-12">
                             {% with "justify-content-center" as pagination_size %}
                                 {% include "partials/pagination.html" %}
                             {% endwith %}
                         </div>
                     </div>
-                    <div class="mt-5 mb-5 row">
+                    <div class="row mt-5 mb-5">
                         <div class="col-12">
                             <div class="form-group">
                                 <label for="validationLink01">Lier pour inviter de nouveaux membres</label>


### PR DESCRIPTION
## Description

🎸 Correction de la mise en forme du  topic-thumbnail


## Type de changement

🪲 Correction de templating et css

### Captures d'écran (optionnel)
Avant
![capture 2023-01-06 à 16 46 58](https://user-images.githubusercontent.com/3874024/211047273-d9943e48-fe7d-4cf0-a815-fb0c2043200e.png)


Apres
![capture 2023-01-06 à 16 49 13](https://user-images.githubusercontent.com/3874024/211047451-0ad41ac5-f81c-4361-b699-a95c36add5c3.png)


