### PR TITLE
Settings: retrait du hook poetry-lock de precommit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,7 +3,6 @@ repos:
     rev: '1.2'
     hooks:
       - id: poetry-check
-      - id: poetry-lock
       - id: poetry-export
         args: ["-f", "requirements.txt", "-o", "requirements/dev.txt", "--with", "dev", "--without-hashes"]
       - id: poetry-export


### PR DESCRIPTION
## Description

🎸 Objectif : dissocier les montées de version des dépendances des évolutions fonctionnelles


## Type de changement

🎨 changement nécessitant une mise à jour de la documentation.

### Points d'attention

🦺 La commande `poetry lock`, ou le script `update_dependancies` devront être executées régulierement, independamment des autres PR. Idéalement en début de releases.


