### PR TITLE
Ajout/Mise à jour des actions Engagement envoyées à Matomo

### DIFF
--- a/lacommunaute/forum/factories.py
+++ b/lacommunaute/forum/factories.py
@@ -8,3 +8,4 @@ from lacommunaute.users.factories import GroupFactory
 class ForumFactory(BaseForumFactory):
     type = Forum.FORUM_POST
     members_group = factory.SubFactory(GroupFactory, name=factory.SelfAttribute("..name"))
+    name = factory.Faker("name")

--- a/lacommunaute/forum/tests.py
+++ b/lacommunaute/forum/tests.py
@@ -101,7 +101,7 @@ class ForumViewTest(TestCase):
         self.assertContains(
             response,
             reverse(
-                "forum_conversation_extension:comment_topic",
+                "forum_conversation_extension:post_create",
                 kwargs={
                     "forum_pk": self.forum.pk,
                     "forum_slug": self.forum.slug,

--- a/lacommunaute/templates/forum/forum_detail.html
+++ b/lacommunaute/templates/forum/forum_detail.html
@@ -44,7 +44,13 @@
                         </button>
                         <div class="dropdown-menu" aria-labelledby="id_dropdown_moderators_stats_button">
                             <a href="{% url 'forum_extension:engagement' forum.slug forum.pk %}" class="dropdown-item">{% trans "Topics Engagement" %}</a>
-                            <a href="{% url 'members:forum_profiles' forum.slug forum.pk %}" class="dropdown-item">{% trans "Members" %}</a>
+                            <a href="{% url 'members:forum_profiles' forum.slug forum.pk %}"
+                                class="dropdown-item matomo-event"
+                                data-matomo-category="engagement"
+                                data-matomo-action="view"
+                                data-matomo-option="directory">
+                                {% trans "Members" %}
+                            </a>
                             {% if request.user.is_staff %}
                                 <a href="{% url 'forum_extension:funnel' forum.slug forum.pk %}" class="dropdown-item">{% trans "Funnel" %}</a>
                             {% endif %}

--- a/lacommunaute/templates/forum/forum_detail.html
+++ b/lacommunaute/templates/forum/forum_detail.html
@@ -29,7 +29,11 @@
             {% if user_can_add_topic or user_can_access_stats %}
                 <div class="col-12 col-sm-auto forum-actions-block">
                     {% if user_can_add_topic %}
-                        <a href="{% url 'forum_conversation:topic_create' forum.slug forum.pk %}" class="btn btn-primary btn-ico">
+                        <a href="{% url 'forum_conversation:topic_create' forum.slug forum.pk %}"
+                            class="btn btn-primary btn-ico matomo-event"
+                            data-matomo-category="engagement"
+                            data-matomo-action="contribute"
+                            data-matomo-option="topic">
                             <i class="ri-chat-new-line ri-lg"></i>
                             <span>{% trans "New topic" %}</span>
                         </a>

--- a/lacommunaute/templates/forum/forum_list.html
+++ b/lacommunaute/templates/forum/forum_list.html
@@ -85,7 +85,6 @@
                                                 By: {{ poster_username }}
                                             {% endblocktrans %}
                                         {% endif %}
-                                        &nbsp;<a href="{% url 'forum_conversation:topic' node.obj.slug node.obj.pk node.last_post.topic.slug node.last_post.topic.pk %}?post={{ node.last_post.pk }}#{{ node.last_post.pk }}"></a>
                                         <br />
                                         <small>{{ node.last_post.created }}</small>
                                     {% else %}
@@ -161,7 +160,6 @@
                                                 By: {{ poster_username }}
                                             {% endblocktrans %}
                                         {% endif %}
-                                        &nbsp;<a href="{% url 'forum_conversation:topic' node.obj.slug node.obj.pk node.last_post.topic.slug node.last_post.topic.pk %}?post={{ node.last_post.pk }}#{{ node.last_post.pk }}"></a>
                                         <br />
                                         <small>{{ node.last_post.created }}</small>
                                     {% else %}

--- a/lacommunaute/templates/forum/forum_list.html
+++ b/lacommunaute/templates/forum/forum_list.html
@@ -15,7 +15,16 @@
                         <div class="mt-3 card forumlist">
                             <div class="p-0 card-header">
                                 <div class="row m-0 px-3 py-2">
-                                    <div class="pl-0 col-md-8 col-12 forum-name-col"><a href="{% url 'forum:forum' node.obj.slug node.obj.id %}" class="text-muted text-uppercase fs-xs">{{ node.obj.name }}</a></div>
+                                    <div class="pl-0 col-md-8 col-12 forum-name-col">
+                                        <a href="{% url 'forum:forum' node.obj.slug node.obj.id %}"
+                                            class="text-muted text-uppercase fs-xs matomo-event"
+                                            data-matomo-category="engagement"
+                                            data-matomo-action="view"
+                                            data-matomo-option="forum"
+                                        >
+                                            {{ node.obj.name }}
+                                        </a>
+                                    </div>
                                     <div class="col-md-1 d-none d-md-block text-center text-nowrap text-muted text-uppercase fs-xs">{% trans "Topics" %}</div>
                                     <div class="col-md-1 d-none d-md-block text-center text-nowrap text-muted text-uppercase fs-xs">{% trans "Posts" %}</div>
                                     <div class="pr-0 col-md-2 d-none d-md-block text-nowrap text-muted text-uppercase fs-xs">{% trans "Last post" %}</div>
@@ -64,7 +73,13 @@
                                                 </td>
                                             {% endif %}
                                             <td class="align-top">
-                                                <a href="{% url 'forum:forum' node.obj.slug node.obj.id %}" class="forum-name-link h4 d-block mb-1">{{ node.obj.name }}</a>
+                                                <a href="{% url 'forum:forum' node.obj.slug node.obj.id %}"
+                                                    class="forum-name-link h4 d-block mb-1 matomo-event"
+                                                    data-matomo-category="engagement"
+                                                    data-matomo-action="view"
+                                                    data-matomo-option="forum">
+                                                    {{ node.obj.name }}
+                                                </a>
                                                 <div class="fs-sm lh-sm">{{ node.obj.description.rendered|urlizetrunc_target_blank:30 }}</div>
                                                 <div class="sub-forums"><p class="fs-sm mb-0">{{ children }}</p></div>
                                             </td>
@@ -76,9 +91,15 @@
                                 <div class="py-2 col-md-2 d-none d-md-block fs-sm">
                                     {% if node.last_post %}
                                         {% if node.last_post.poster %}
-                                            {% url 'forum_member:profile' node.last_post.poster_id as poster_url %}
+                                            {% url 'members:profile' node.last_post.poster_id as poster_url %}
                                             {% blocktrans trimmed with poster_url=poster_url username=node.last_post.poster|forum_member_display_name %}
-                                                By: <a href="{{ poster_url }}">{{ username }}</a>
+                                                By: <a href="{{ poster_url }}"
+                                                    class="matomo-event"
+                                                    data-matomo-category="engagement"
+                                                    data-matomo-action="view"
+                                                    data-matomo-option="member">
+                                                    {{ username }}
+                                                </a>
                                             {% endblocktrans %}
                                         {% else %}
                                             {% blocktrans trimmed with poster_username="Utilisateur anonyme" %}
@@ -97,7 +118,13 @@
                                         <tr>
                                             <td class="pt-1 pr-3 align-top forum-icon link"><i class="fas fa-link fa-2x"></i></td>
                                             <td class="align-top">
-                                                <a href="{% url 'forum:forum' node.obj.slug node.obj.id %}" class="forum-name-link h4 d-block mb-1">{{ node.obj.name }}</a>
+                                                <a href="{% url 'forum:forum' node.obj.slug node.obj.id %}"
+                                                    class="forum-name-link h4 d-block mb-1 matomo-event"
+                                                    data-matomo-category="engagement"
+                                                    data-matomo-action="view"
+                                                    data-matomo-option="forum">
+                                                    {{ node.obj.name }}
+                                                </a>
                                                 <div class="forum-description">{{ node.obj.description.rendered }}</div>
                                             </td>
                                         </tr>
@@ -139,7 +166,13 @@
                                                 </td>
                                             {% endif %}
                                             <td class="align-top">
-                                                <a href="{% url 'forum:forum' node.obj.slug node.obj.id %}" class="forum-name-link h4 d-block mb-1">{{ node.obj.name }}</a>
+                                                <a href="{% url 'forum:forum' node.obj.slug node.obj.id %}"
+                                                    class="forum-name-link h4 d-block mb-1 matomo-event"
+                                                    data-matomo-category="engagement"
+                                                    data-matomo-action="view"
+                                                    data-matomo-option="forum">
+                                                    {{ node.obj.name }}
+                                                </a>
                                                 <div class="forum-description">{{ node.obj.description.rendered }}</div>
                                                 <div class="sub-forums"><small>{{ children }}</small></div>
                                             </td>
@@ -151,9 +184,15 @@
                                 <div class="py-2 col-md-2 d-none d-md-block fs-sm">
                                     {% if node.last_post %}
                                         {% if node.last_post.poster_id %}
-                                            {% url 'forum_member:profile' node.last_post.poster_id as poster_url %}
+                                            {% url 'members:profile' node.last_post.poster_id as poster_url %}
                                             {% blocktrans trimmed with poster_url=poster_url username=node.last_post.poster|forum_member_display_name %}
-                                                By: <a href="{{ poster_url }}">{{ username }}</a>
+                                                By: <a href="{{ poster_url }}"
+                                                    class="matomo-event"
+                                                    data-matomo-category="engagement"
+                                                    data-matomo-action="view"
+                                                    data-matomo-option="member">
+                                                    {{ username }}
+                                                </a>
                                             {% endblocktrans %}
                                         {% else %}
                                             {% blocktrans trimmed with poster_username=node.last_post.username %}
@@ -172,7 +211,13 @@
                                         <tr>
                                             <td class="pt-1 pr-3 align-top forum-icon link"><i class="fas fa-link fa-2x"></i></td>
                                             <td class="align-top">
-                                                <a href="{% url 'forum:forum' node.obj.slug node.obj.id %}" class="forum-name-link h4 d-block mb-1">{{ node.obj.name }}</a>
+                                                <a href="{% url 'forum:forum' node.obj.slug node.obj.id %}"
+                                                    class="forum-name-link h4 d-block mb-1 matomo-event"
+                                                    data-matomo-category="engagement"
+                                                    data-matomo-action="view"
+                                                    data-matomo-option="forum">
+                                                    {{ node.obj.name }}
+                                                </a>
                                                 <div class="forum-description">{{ node.obj.description.rendered }}</div>
                                             </td>
                                         </tr>
@@ -191,13 +236,31 @@
                         {% if not node.previous_sibling %}
                             <b>{% trans "Subforums:" %}</b>&nbsp;
                         {% endif %}
-                        <i class="fas fa-file"></i>&nbsp;<a href="{% url 'forum:forum' node.obj.slug node.obj.id %}">{{ node.obj.name }}</a>&nbsp;&nbsp;
+                        <i class="fas fa-file"></i>
+                        &nbsp;
+                        <a href="{% url 'forum:forum' node.obj.slug node.obj.id %}"
+                            class="matomo-event"
+                            data-matomo-category="engagement"
+                            data-matomo-action="view"
+                            data-matomo-option="forum">
+                            {{ node.obj.name }}
+                        </a>
+                        &nbsp;&nbsp;
                     {% endif %}
                 {% elif node.level == root_level_sub %}
                     {% if not node.previous_sibling %}
                         <b>{% trans "Subforums:" %}</b>&nbsp;
                     {% endif %}
-                    <i class="fas fa-file"></i>&nbsp;<a href="{% url 'forum:forum' node.obj.slug node.obj.id %}">{{ node.obj.name }}</a>&nbsp;&nbsp;
+                    <i class="fas fa-file"></i>
+                    &nbsp;
+                    <a href="{% url 'forum:forum' node.obj.slug node.obj.id %}"
+                        class="matomo-event"
+                        data-matomo-category="engagement"
+                        data-matomo-action="view"
+                        data-matomo-option="forum">
+                        {{ node.obj.name }}
+                    </a>
+                    &nbsp;&nbsp;
                 {% endif %}
             {% endrecurseforumcontents %}
         {% else %}

--- a/lacommunaute/templates/forum/funnel.html
+++ b/lacommunaute/templates/forum/funnel.html
@@ -14,7 +14,7 @@
                         <ol class="breadcrumb">
                             <li class="breadcrumb-item"><a href="{% url 'pages:home' %}">Accueil</a></li>
                             <li class="breadcrumb-item"><a href="{% url 'forum:index' %}">{% trans "Forum" %}</a></li>
-                            <li class="breadcrumb-item active">
+                            <li class="breadcrumb-item">
                                 <a href="{% url 'forum:forum' forum.slug forum.id %}"
                                     class="matomo-event"
                                     data-matomo-category="engagement"

--- a/lacommunaute/templates/forum/funnel.html
+++ b/lacommunaute/templates/forum/funnel.html
@@ -14,7 +14,15 @@
                         <ol class="breadcrumb">
                             <li class="breadcrumb-item"><a href="{% url 'pages:home' %}">Accueil</a></li>
                             <li class="breadcrumb-item"><a href="{% url 'forum:index' %}">{% trans "Forum" %}</a></li>
-                            <li class="breadcrumb-item active"><a href="{% url 'forum:forum' forum.slug forum.id %}">{{ forum.name }}</a></li>
+                            <li class="breadcrumb-item active">
+                                <a href="{% url 'forum:forum' forum.slug forum.id %}"
+                                    class="matomo-event"
+                                    data-matomo-category="engagement"
+                                    data-matomo-action="view"
+                                    data-matomo-option="forum">
+                                    {{ forum.name }}
+                                </a>
+                            </li>
                             <li class="breadcrumb-item active" aria-current="page">{% trans "Funnel" %}</li>
                         </ol>
                     </nav>

--- a/lacommunaute/templates/forum/moderator_engagement.html
+++ b/lacommunaute/templates/forum/moderator_engagement.html
@@ -14,7 +14,15 @@
                         <ol class="breadcrumb">
                             <li class="breadcrumb-item"><a href="{% url 'pages:home' %}">Accueil</a></li>
                             <li class="breadcrumb-item"><a href="{% url 'forum:index' %}">{% trans "Forum" %}</a></li>
-                            <li class="breadcrumb-item active"><a href="{% url 'forum:forum' forum.slug forum.id %}">{{ forum.name }}</a></li>
+                            <li class="breadcrumb-item active">
+                                <a href="{% url 'forum:forum' forum.slug forum.id %}"
+                                    class="matomo-event"
+                                    data-matomo-category="engagement"
+                                    data-matomo-action="view"
+                                    data-matomo-option="forum">
+                                    {{ forum.name }}
+                                </a>
+                            </li>
                             <li class="breadcrumb-item active" aria-current="page">Engagement</li>{% comment %} TODO: Dynamiser la valeur engagement {% endcomment %}
                         </ol>
                     </nav>

--- a/lacommunaute/templates/forum/moderator_engagement.html
+++ b/lacommunaute/templates/forum/moderator_engagement.html
@@ -14,7 +14,7 @@
                         <ol class="breadcrumb">
                             <li class="breadcrumb-item"><a href="{% url 'pages:home' %}">Accueil</a></li>
                             <li class="breadcrumb-item"><a href="{% url 'forum:index' %}">{% trans "Forum" %}</a></li>
-                            <li class="breadcrumb-item active">
+                            <li class="breadcrumb-item">
                                 <a href="{% url 'forum:forum' forum.slug forum.id %}"
                                     class="matomo-event"
                                     data-matomo-category="engagement"

--- a/lacommunaute/templates/forum_conversation/forum_polls/topic_list_poll_detail.html
+++ b/lacommunaute/templates/forum_conversation/forum_polls/topic_list_poll_detail.html
@@ -39,7 +39,11 @@
             </div>
         {% elif can_be_completed and has_been_completed and not change_vote_action %}
             <div class="form-actions">
-                <a href="{% url 'forum_conversation:topic' poll.topic.forum.slug poll.topic.forum.pk poll.topic.slug poll.topic.pk %}?change_vote=true" class="btn btn-sm btn-link pl-0">
+                <a href="{% url 'forum_conversation:topic' poll.topic.forum.slug poll.topic.forum.pk poll.topic.slug poll.topic.pk %}?change_vote=true"
+                    class="btn btn-sm btn-link pl-0 matomo-event"
+                    data-matomo-category="engagement"
+                    data-matomo-action="view"
+                    data-matomo-option="topic">
                     {% trans "Change your vote" %}
                 </a>
             </div>

--- a/lacommunaute/templates/forum_conversation/forum_polls/topic_list_poll_vote_form.html
+++ b/lacommunaute/templates/forum_conversation/forum_polls/topic_list_poll_vote_form.html
@@ -27,6 +27,10 @@
         {% endfor %}
     </ul>
     <div class="form-actions">
-        <input type="submit" class="btn btn-sm btn-secondary matomo-event" value="{% trans "Submit" %}" data-matomo-category="engagement" data-matomo-action="vote"/>
+        <input type="submit" class="btn btn-sm btn-secondary matomo-event"
+            value="{% trans "Submit" %}"
+            data-matomo-category="engagement"
+            data-matomo-action="vote"
+            data-matomo-option="poll"/>
     </div>
 </form>

--- a/lacommunaute/templates/forum_conversation/partials/post_feed_form_collapsable.html
+++ b/lacommunaute/templates/forum_conversation/partials/post_feed_form_collapsable.html
@@ -9,7 +9,7 @@
             <div class="card-body">
                 <div class="row">
                     <div class="col-12 post-content-wrapper">
-                        <form hx-post="{% url 'forum_conversation_extension:comment_topic' topic.forum.slug topic.forum.pk topic.slug topic.pk %}"
+                        <form hx-post="{% url 'forum_conversation_extension:post_create' topic.forum.slug topic.forum.pk topic.slug topic.pk %}"
                             hx-target="#postinfeedarea{{topic.pk}}"
                             hx-swap="outerHTML"
                             class="majorpoints"

--- a/lacommunaute/templates/forum_conversation/partials/post_feed_form_collapsable.html
+++ b/lacommunaute/templates/forum_conversation/partials/post_feed_form_collapsable.html
@@ -12,8 +12,10 @@
                         <form hx-post="{% url 'forum_conversation_extension:post_create' topic.forum.slug topic.forum.pk topic.slug topic.pk %}"
                             hx-target="#postinfeedarea{{topic.pk}}"
                             hx-swap="outerHTML"
-                            class="majorpoints"
-                        >
+                            class="majorpoints matomo-event"
+                            data-matomo-category="engagement"
+                            data-matomo-action="contribute"
+                            data-matomo-option="post">
                             {% csrf_token %}
 
                             {% if post_form.non_field_errors %}

--- a/lacommunaute/templates/forum_conversation/partials/post_upvotes.html
+++ b/lacommunaute/templates/forum_conversation/partials/post_upvotes.html
@@ -15,7 +15,7 @@
                     class="btn btn-ico btn-link pr-0 matomo-event"
                     data-matomo-category="engagement"
                     data-matomo-action="upvote"
-                    data-matomo-option="{% if post.has_upvoted %}disupvote{%else%}upvote{%endif%}"
+                    data-matomo-option="{% if post.has_upvoted %}downvote{%else%}upvote{%endif%}"
                 >
                     <i class="{% if post.has_upvoted %}ri-star-fill{%else%}ri-star-line{%endif%}" aria-hidden="true"></i>
                     <span>{{counter}} vote{{ counter|pluralizefr }}</span>

--- a/lacommunaute/templates/forum_conversation/partials/poster.html
+++ b/lacommunaute/templates/forum_conversation/partials/poster.html
@@ -10,7 +10,14 @@
         {% if post.poster %}
             {% url 'members:profile' post.poster_id as poster_url %}
             {% blocktrans trimmed with poster_url=poster_url username=post.poster|forum_member_display_name creation_date=post.created %}
-                By: <a href="{{ poster_url }}">{{ username }}</a>,
+                By:
+                <a href="{{ poster_url }}"
+                    class="matomo-event"
+                    data-matomo-category="engagement"
+                    data-matomo-action="view"
+                    data-matomo-option="member">
+                    {{ username }}
+                </a>,
             {% endblocktrans %}
         {% else %}
             {% blocktrans trimmed with poster_username="Utilisateur anonyme" creation_date=post.created %}

--- a/lacommunaute/templates/forum_conversation/partials/topic_form.html
+++ b/lacommunaute/templates/forum_conversation/partials/topic_form.html
@@ -91,7 +91,10 @@
             <input type="submit" name="preview" class="btn btn-outline-primary" value="{% trans "Preview" %}" />
         </div>
         <div class="form-group col-auto">
-            <input type="submit" class="btn btn-primary" value="{% trans "Submit" %}" />
+            <input type="submit" class="btn btn-primary matomo-event" value="{% trans "Submit" %}"
+                data-matomo-category="engagement"
+                data-matomo-action="contribute"
+                data-matomo-option="topic" />
         </div>
         {% if post %}
             {% get_permission 'can_delete_post' post request.user as user_can_delete_post %}

--- a/lacommunaute/templates/forum_conversation/partials/topic_likes.html
+++ b/lacommunaute/templates/forum_conversation/partials/topic_likes.html
@@ -8,7 +8,9 @@
                 hx-target="#likesarea{{topic.pk}}"
                 hx-swap="outerHTML"
                 class="btn btn-ico btn-link btn-like pr-0 matomo-event"
-                data-matomo-category="engagement" data-matomo-action="like" data-matomo-option="{% if topic.has_liked %}unlike{%else%}like{%endif%}"
+                data-matomo-category="engagement"
+                data-matomo-action="like"
+                data-matomo-option="{% if topic.has_liked %}unlike{%else%}like{%endif%}"
             >
                 <i class="{% if topic.has_liked %}ri-heart-3-fill{%else%}ri-heart-3-line{%endif%}" aria-hidden="true"></i>
                 <span>{{counter}} {% trans "Likes" %}</span>

--- a/lacommunaute/templates/forum_conversation/post_create.html
+++ b/lacommunaute/templates/forum_conversation/post_create.html
@@ -28,7 +28,10 @@
                                 <input type="submit" name="preview" class="btn btn-outline-primary" value="{% trans "Preview" %}" />
                             </div>
                             <div class="form-group col-auto">
-                                <input type="submit" class="btn btn-primary" value="{% trans "Submit" %}" />
+                                <input type="submit" class="btn btn-primary matomo-event" value="{% trans "Submit" %}"
+                                    data-matomo-category="engagement"
+                                    data-matomo-action="contribute"
+                                    data-matomo-option="post"> />
                             </div>
                         </div>
                     </form>

--- a/lacommunaute/templates/forum_conversation/post_create.html
+++ b/lacommunaute/templates/forum_conversation/post_create.html
@@ -54,9 +54,16 @@
                                     {% spaceless %}
                                         <i class="fa fa-clock-o"></i>&nbsp;
                                         {% if post.poster %}
-                                            {% url 'forum_member:profile' post.poster_id as poster_url %}
+                                            {% url 'members:profile' post.poster_id as poster_url %}
                                             {% blocktrans trimmed with poster_url=poster_url username=post.poster|forum_member_display_name creation_date=post.created %}
-                                                By: <a href="{{ poster_url }}">{{ username }}</a> on {{ creation_date }}
+                                                By: <a href="{{ poster_url }}"
+                                                    class="matomo-event"
+                                                    data-matomo-category="engagement"
+                                                    data-matomo-action="view"
+                                                    data-matomo-option="member">
+                                                    {{ username }}
+                                                </a>
+                                                on {{ creation_date }}
                                             {% endblocktrans %}
                                         {% else %}
                                             {% blocktrans trimmed with poster_username=post.username creation_date=post.created %}
@@ -71,7 +78,19 @@
                                 {% include "forum_conversation/forum_attachments/attachments_detail.html" %}
                             </div>
                             <div class="col-md-2 post-sidebar">
-                                <div class="username">{% if post.poster %}<a href="{% url 'forum_member:profile' post.poster_id %}"><b>{{ post.poster|forum_member_display_name }}</b></a>{% else %}<b>{{ post.username }}</b>{% endif %}</div>
+                                <div class="username">
+                                    {% if post.poster %}
+                                        <a href="{% url 'members:profile' post.poster_id %}"
+                                            class="matomo-event"
+                                            data-matomo-category="engagement"
+                                            data-matomo-action="view"
+                                            data-matomo-option="member">
+                                            <b>{{ post.poster|forum_member_display_name }}</b>
+                                        </a>
+                                    {% else %}
+                                        <b>{{ post.username }}</b>
+                                    {% endif %}
+                                </div>
                             </div>
                         </div>
                     {% endfor %}

--- a/lacommunaute/templates/forum_conversation/topic_list.html
+++ b/lacommunaute/templates/forum_conversation/topic_list.html
@@ -34,7 +34,11 @@
                                             <span class="topic-icon font-weight-normal {% if topic in unread_topics or force_all_unread %}unread{% endif %}">
                                                 <i class="{% if topic.is_sticky %}ri-lightbulb-flash-line{% elif topic.is_announce %}ri-information-line{% else %}ri-record-circle-line{% endif %} ri-xl"></i>
                                             </span>
-                                            <a href="{% url 'forum_conversation:topic' topic.forum.slug topic.forum.pk topic.slug topic.pk %}">
+                                            <a href="{% url 'forum_conversation:topic' topic.forum.slug topic.forum.pk topic.slug topic.pk %}"
+                                                class="matomo-event"
+                                                data-matomo-category="engagement"
+                                                data-matomo-action="view"
+                                                data-matomo-option="topic">
                                                 {{ topic.subject }} {% if topic.is_locked %}&nbsp;<i class="fas fa-times-circle locked-indicator" title="{% trans 'This topic is locked' %}"></i>{% endif %}
                                             </a>
                                         </p>

--- a/lacommunaute/templates/forum_member/forum_profile_detail.html
+++ b/lacommunaute/templates/forum_member/forum_profile_detail.html
@@ -39,7 +39,13 @@
                                 <div class="row post">
                                     <div class="col-md-12 post-content-wrapper">
                                         <div class="post-title">
-                                            <a href="{% url 'forum_conversation:topic' post.topic.forum.slug post.topic.forum.pk post.topic.slug post.topic.pk %}?post={{ post.pk }}#{{ post.pk }}">{{ post.topic.subject }}</a>
+                                            <a href="{% url 'forum_conversation:topic' post.topic.forum.slug post.topic.forum.pk post.topic.slug post.topic.pk %}?post={{ post.pk }}#{{ post.pk }}"
+                                                class="matomo-event"
+                                                data-matomo-category="engagement"
+                                                data-matomo-action="view"
+                                                data-matomo-option="topic">
+                                                {{ post.topic.subject }}
+                                            </a>
                                         </div>
                                         <p>
                                             <small class="text-muted">

--- a/lacommunaute/templates/forum_member/moderator_profiles.html
+++ b/lacommunaute/templates/forum_member/moderator_profiles.html
@@ -25,7 +25,13 @@
                             <div class="card">
                                 <div class="card-body">
                                     <h3 class="h5 card-title">
-                                        <a href="{%url 'forum_member:profile' pk=forum_profile.user_id%}">{{ forum_profile.user.get_full_name }}</a>
+                                        <a href="{%url 'members:profile' pk=forum_profile.user_id%}"
+                                            class="matomo-event"
+                                            data-matomo-category="engagement"
+                                            data-matomo-action="view"
+                                            data-matomo-option="member">
+                                            {{ forum_profile.user.get_full_name }}
+                                        </a>
                                     </h3>
                                 </div>
                             </div>

--- a/lacommunaute/templates/forum_member/profiles.html
+++ b/lacommunaute/templates/forum_member/profiles.html
@@ -43,7 +43,13 @@
                                 {% endif %}
                                 <div class="card-body">
                                     <h3 class="h5 card-title">
-                                        <a href="{%url 'forum_member:profile' pk=forum_profile.user_id%}">{{ forum_profile.user.get_full_name }}</a>
+                                        <a href="{%url 'members:profile' pk=forum_profile.user_id%}"
+                                            class="matomo-event"
+                                            data-matomo-category="engagement"
+                                            data-matomo-action="view"
+                                            data-matomo-option="member">
+                                            {{ forum_profile.user.get_full_name }}
+                                        </a>
                                     </h3>
                                     {% if forum_profile.signature %}
                                         <p class="card-text">{{ forum_profile.signature }}</p>

--- a/lacommunaute/templates/pages/home.html
+++ b/lacommunaute/templates/pages/home.html
@@ -82,7 +82,11 @@
                             </div>
                             <div class="card-footer text-right">
                                 {% if user_can_read_forum %}
-                                    <a href="{% url 'forum:forum' forum.slug forum.id %}" class="btn btn-ico btn-link stretched-link">
+                                    <a href="{% url 'forum:forum' forum.slug forum.id %}"
+                                        class="btn btn-ico btn-link stretched-link matomo-event"
+                                        data-matomo-category="engagement"
+                                        data-matomo-action="view"
+                                        data-matomo-option="forum">
                                         <span>{% trans "Go to this forum" %}</span>
                                         <i class="ri-external-link-line ri-lg"></i>
                                     </a>

--- a/lacommunaute/templates/partials/breadcrumb.html
+++ b/lacommunaute/templates/partials/breadcrumb.html
@@ -9,9 +9,25 @@
                         <li class="breadcrumb-item"><a href="{% url 'forum:index' %}">{% trans "Forum" %}</a></li>
                         {% if forum %}
                             {% for ancestor in forum.get_ancestors %}
-                                <li class="breadcrumb-item"><a href="{% url 'forum:forum' ancestor.slug ancestor.id %}">{{ ancestor.name }}</a></li>
+                                <li class="breadcrumb-item">
+                                    <a href="{% url 'forum:forum' ancestor.slug ancestor.id %}"
+                                        class="matomo-event"
+                                        data-matomo-category="engagement"
+                                        data-matomo-action="view"
+                                        data-matomo-option="forum">
+                                        {{ ancestor.name }}
+                                    </a>
+                                </li>
                             {% endfor %}
-                            <li class="breadcrumb-item"><a href="{% url 'forum:forum' forum.slug forum.id %}">{{ forum.name }}</a></li>
+                            <li class="breadcrumb-item">
+                                <a href="{% url 'forum:forum' forum.slug forum.id %}"
+                                    class="matomo-event"
+                                    data-matomo-category="engagement"
+                                    data-matomo-action="view"
+                                    data-matomo-option="forum">
+                                    {{ forum.name }}
+                                </a>
+                            </li>
                         {% endif %}
                         {% if topic %}
                             <li class="breadcrumb-item active">{{ topic.subject }}</li>

--- a/lacommunaute/templates/partials/header_nav_primary_items.html
+++ b/lacommunaute/templates/partials/header_nav_primary_items.html
@@ -28,7 +28,13 @@
                         <div class="dropdown-divider"></div>
                     </li>
                     <li>
-                        <a class="dropdown-item text-primary" href="{% url 'members:profile' user.id %}">Accéder à mon profil</a>
+                        <a href="{% url 'members:profile' user.id %}"
+                            class="dropdown-item text-primary matomo-event"
+                            data-matomo-category="engagement"
+                            data-matomo-action="view"
+                            data-matomo-option="member">
+                            Accéder à mon profil
+                        </a>
                     </li>
                     {% if user.is_superuser %}
                         <li>

--- a/lacommunaute/www/forum_conversation/tests.py
+++ b/lacommunaute/www/forum_conversation/tests.py
@@ -254,7 +254,7 @@ class PostFeedCreateViewTest(TestCase):
         cls.topic = TopicFactory()
         cls.user = cls.topic.poster
         cls.url = reverse(
-            "forum_conversation_extension:comment_topic",
+            "forum_conversation_extension:post_create",
             kwargs={
                 "forum_pk": cls.topic.forum.pk,
                 "forum_slug": cls.topic.forum.slug,
@@ -279,7 +279,7 @@ class PostFeedCreateViewTest(TestCase):
 
         response = self.client.post(
             reverse(
-                "forum_conversation_extension:comment_topic",
+                "forum_conversation_extension:post_create",
                 kwargs={
                     "forum_pk": self.topic.forum.pk,
                     "forum_slug": self.topic.forum.slug,

--- a/lacommunaute/www/forum_conversation/urls.py
+++ b/lacommunaute/www/forum_conversation/urls.py
@@ -9,7 +9,7 @@ conversation_urlpatterns = [
     path("topic/<str:slug>-<int:pk>/like", TopicLikeView.as_view(), name="like_topic"),
     path("topic/<str:slug>-<int:pk>/showmore/topic", TopicContentView.as_view(), name="showmore_topic"),
     path("topic/<str:slug>-<int:pk>/showmore/posts", PostListView.as_view(), name="showmore_posts"),
-    path("topic/<str:slug>-<int:pk>/comment", PostFeedCreateView.as_view(), name="comment_topic"),
+    path("topic/<str:slug>-<int:pk>/comment", PostFeedCreateView.as_view(), name="post_create"),
 ]
 
 urlpatterns = [

--- a/lacommunaute/www/forum_member/tests.py
+++ b/lacommunaute/www/forum_member/tests.py
@@ -39,7 +39,7 @@ class ForumProfileListViewTest(TestCase):
                 self.assertContains(
                     response,
                     # legacy machina reversed url
-                    reverse("forum_member:profile", kwargs={"pk": forum_profile.user_id}),
+                    reverse("members:profile", kwargs={"pk": forum_profile.user_id}),
                 )
 
 
@@ -83,7 +83,7 @@ class ModeratorProfileListView(TestCase):
         self.client.force_login(self.profile.user)
         response = self.client.get(self.url)
         self.assertContains(response, forum_profile.user.get_full_name())
-        self.assertContains(response, reverse("forum_member:profile", kwargs={"pk": forum_profile.user_id}))
+        self.assertContains(response, reverse("members:profile", kwargs={"pk": forum_profile.user_id}))
 
     def test_ordering_and_count(self):
         self.forum.members_group.user_set.add(ForumProfileFactory(user__first_name="z").user)


### PR DESCRIPTION
## Description

🎸 ajout des actions `contribute`  sur la création de `topic` et de `post`
🎸 ajout des actions `view`  des pages de `topic`, `forum`, `profile`, `forum_profiles`
🎸 correction de l'action `vote` : ajout de `data-matomo-option`
🎸 correction de l'action `upvote` : rennomage de l'option en `downvote`
 
## Type de changement

🎢 MISE A JOUR fonctionnalité

### Points d'attention

🦺 remplacement de l'url `machina` `forum_member:profile` par l'url surchargée `members:profile`
🦺 renommage de l'url `forum_conversation_extension:comment_topic` par `forum_conversation_extension:post_create` pour plus de consistence