### PR TITLE
Suppression de la vue de tous les membres du Forum

### DIFF
--- a/lacommunaute/www/forum_member/tests.py
+++ b/lacommunaute/www/forum_member/tests.py
@@ -7,7 +7,6 @@ from machina.core.loading import get_class
 from machina.test.factories.forum import create_forum
 
 from lacommunaute.forum_member.factories import ForumProfileFactory
-from lacommunaute.forum_member.models import ForumProfile
 from lacommunaute.users.factories import DEFAULT_PASSWORD, UserFactory
 from lacommunaute.www.forum_member.views import ForumProfileUpdateView
 
@@ -23,24 +22,6 @@ class ForumProfileUpdateViewTest(TestCase):
         view.request = RequestFactory().get("/")
         view.request.user = forum_profiles.user
         self.assertEqual(view.get_success_url(), reverse("members:profile", kwargs={"pk": forum_profiles.user.pk}))
-
-
-class ForumProfileListViewTest(TestCase):
-    def test_ForumProfileListView(self):
-        forum_profiles = ForumProfileFactory.create_batch(2)
-        response = self.client.get(reverse("members:profiles"))
-
-        self.assertEqual(response.status_code, 200)
-        self.assertEqual(len(response.context["forum_profiles"]), ForumProfile.objects.count())
-
-        for forum_profile in forum_profiles:
-            with self.subTest(forum_profile=forum_profile):
-                self.assertContains(response, forum_profile.user.first_name)
-                self.assertContains(
-                    response,
-                    # legacy machina reversed url
-                    reverse("members:profile", kwargs={"pk": forum_profile.user_id}),
-                )
 
 
 class ModeratorProfileListView(TestCase):

--- a/lacommunaute/www/forum_member/urls.py
+++ b/lacommunaute/www/forum_member/urls.py
@@ -2,7 +2,6 @@ from django.urls import path
 
 from lacommunaute.www.forum_member.views import (
     ForumProfileDetailView,
-    ForumProfileListView,
     ForumProfileUpdateView,
     JoinForumFormView,
     JoinForumLandingView,
@@ -13,7 +12,6 @@ from lacommunaute.www.forum_member.views import (
 app_name = "members"
 
 urlpatterns = [
-    path("", ForumProfileListView.as_view(), name="profiles"),
     path("profile/edit/", ForumProfileUpdateView.as_view(), name="profile_update"),
     path("profile/<str:pk>/", ForumProfileDetailView.as_view(), name="profile"),
     path("forum/<str:slug>-<int:pk>/", ModeratorProfileListView.as_view(), name="forum_profiles"),

--- a/lacommunaute/www/forum_member/views.py
+++ b/lacommunaute/www/forum_member/views.py
@@ -32,12 +32,6 @@ class ForumProfileUpdateView(BaseForumProfileUpdateView):
         return reverse("members:profile", kwargs={"pk": self.request.user.pk})
 
 
-class ForumProfileListView(ListView):
-    model = ForumProfile
-    template_name = "forum_member/profiles.html"
-    context_object_name = "forum_profiles"
-
-
 class ModeratorProfileListView(PermissionRequiredMixin, ListView):
     model = ForumProfile
     template_name = "forum_member/moderator_profiles.html"


### PR DESCRIPTION
## Description

🎸 La vue `members:profiles` liste l'intégralité des membres de la plateforme. Cette vue n'est référencée dans aucune autre vue => suppression

## Type de changement

🥊 suppression code mort
