### PR TITLE
[fix urgent] Stats - ordonner les périodes pour les graphes

### DIFF
--- a/lacommunaute/utils/stats.py
+++ b/lacommunaute/utils/stats.py
@@ -40,6 +40,6 @@ def format_counts_of_objects_for_timeline_chart(datas):
     # }
     chart_arrays = {}
     for name in names:
-        chart_arrays[name] = [merged_periods[k].get(name, 0) for k in merged_periods.keys()]
+        chart_arrays[name] = [merged_periods[k].get(name, 0) for k in sorted(merged_periods.keys())]
 
     return chart_arrays


### PR DESCRIPTION
## Description

🎸 trier les périodes par ordre croissant dans les graphes de statistiques

## Type de changement

🪲 Correction de bug (changement non cassant qui corrige un problème).

### Points d'attention

🦺 correction rapide, ne resout pas le sujet des périodes sans donnée.


