### PR TITLE
FIX PR139 - Stats - ordonner les périodes pour les graphes

### DIFF
--- a/lacommunaute/forum/models.py
+++ b/lacommunaute/forum/models.py
@@ -34,31 +34,27 @@ class Forum(AbstractForum):
             count_objects_per_period(
                 Topic.objects.filter(forum__in=forums, created__gte=start_date).annotate(period=TruncWeek("created")),
                 "topics",
-                PeriodAggregation.WEEK,
             )
             + count_objects_per_period(
                 Post.objects.filter(topic__forum__in=forums, created__gte=start_date).annotate(
                     period=TruncWeek("created")
                 ),
                 "posts",
-                PeriodAggregation.WEEK,
             )
             + count_objects_per_period(
                 UpVote.objects.filter(post__topic__forum__in=forums, created_at__gte=start_date).annotate(
                     period=TruncWeek("created_at")
                 ),
                 "upvotes",
-                PeriodAggregation.WEEK,
             )
             + count_objects_per_period(
                 TopicPollVote.objects.filter(
                     poll_option__poll__topic__forum__in=forums, timestamp__gte=start_date
                 ).annotate(period=TruncWeek("timestamp")),
                 "pollvotes",
-                PeriodAggregation.WEEK,
             )
         )
-        return format_counts_of_objects_for_timeline_chart(datas)
+        return format_counts_of_objects_for_timeline_chart(datas, period=PeriodAggregation.WEEK)
 
     @cached_property
     def count_engaged_users(self):

--- a/lacommunaute/utils/stats.py
+++ b/lacommunaute/utils/stats.py
@@ -5,41 +5,35 @@ from django.db.models import Count
 from lacommunaute.utils.enums import PeriodAggregation
 
 
-def count_objects_per_period(qs, name, period=PeriodAggregation.MONTH):
+def get_strftime(period=PeriodAggregation.MONTH):
     if period == PeriodAggregation.WEEK:
-        ft = "%Y-%W"
-    elif period == PeriodAggregation.MONTH:
-        ft = "%b %Y"
-    else:
-        raise ValueError("unknown period")
+        return "%Y-%W"
+    if period == PeriodAggregation.MONTH:
+        return "%b %Y"
+    raise ValueError("unknown period")
 
-    # [{'period': 'Dec 2022', '<model name>': 59}, {'period': 'Jan 2023', '<model name>': 25}]
+
+def count_objects_per_period(qs, name):
+
     qs = qs.values("period").annotate(number=Count("id")).values("period", "number").order_by("period")
-    return [{"period": item["period"].strftime(ft), name: item["number"]} for item in qs]
+    return [{"period": item["period"], name: item["number"]} for item in qs]
 
 
-def format_counts_of_objects_for_timeline_chart(datas):
+def format_counts_of_objects_for_timeline_chart(datas, period=PeriodAggregation.MONTH):
+    # TODO vincentporte : manage period without datas between oldest period and now
 
-    # aggregate counts of objects per month in a dict
-    # {'Dec 2022': {'period': 'Dec 2022', 'users': 59, 'posts': 5, 'upvotes': 3},
-    #  'Jan 2023': {'period': 'Jan 2023', 'users': 25, 'posts': 39, 'upvotes': 11, 'pollvotes': 26}
-    # }
     merged_periods = defaultdict(dict)
     for data in datas:
         merged_periods[data["period"]] |= data
 
-    # objects name
     names = dict(ChainMap(*datas)).keys()
 
-    # extract one array per object name
-    # {'period': ['Dec 2022', 'Jan 2023'],
-    #  'pollvotes': [0, 26],
-    #  'upvotes': [3, 11],
-    #  'posts': [5, 39],
-    #  'users': [59, 25]
-    # }
     chart_arrays = {}
     for name in names:
         chart_arrays[name] = [merged_periods[k].get(name, 0) for k in sorted(merged_periods.keys())]
+
+    # datetime must be formatted AFTER being sorted
+    ft = get_strftime(period)
+    chart_arrays["period"] = [v.strftime(ft) for v in chart_arrays["period"]]
 
     return chart_arrays


### PR DESCRIPTION
## Description

🎸 Formatter les dates après leur tri

## Type de changement

🪲 Correction de bug (changement non cassant qui corrige un problème).

### Points d'attention

🦺 Ce patch devra être modifié pour gérer les périodes sans données entre la plus ancienne période et maintenant

### copies d'écrans

Par mois

![image](https://user-images.githubusercontent.com/11419273/212255305-8e53866b-befa-4f82-8656-072874d71c74.png)

Par semaine

![image](https://user-images.githubusercontent.com/11419273/212255499-6cdddd3d-b188-430d-89cf-34e09a5717b6.png)
