### PR TITLE
Réduction de largeur de colonne du post-content

### DIFF
--- a/lacommunaute/templates/forum_conversation/post_preview.html
+++ b/lacommunaute/templates/forum_conversation/post_preview.html
@@ -7,7 +7,7 @@
         <div class="card post post-preview">
             <div class="card-body">
                 <div class="row">
-                    <div class="col-md-12 post-content-wrapper">
+                    <div class="col-12 post-content-wrapper">
                         <h3 class="h4 mb-0">Votre {% trans "Preview"|lower %}</h3>
                         <hr>
                         <div class="post-content">

--- a/lacommunaute/templates/forum_conversation/topic_detail.html
+++ b/lacommunaute/templates/forum_conversation/topic_detail.html
@@ -28,7 +28,7 @@
                     {% endif %}
                     <div class="card-body {% if forloop.first%} pt-0 {% else %} bg-light{%endif%}">
                         <div class="row">
-                            <div class="col-md-12 post-content-wrapper">
+                            <div class="col-12 post-content-wrapper">
                                 {% if not forloop.first %}
                                     <div class="d-flex align-items-center mb-1">
                                         <span class="mb-0 flex-grow-1">
@@ -37,11 +37,12 @@
                                         {% include "forum_conversation/partials/post_upvotes.html"%}
                                     </div>
                                 {%endif%}
-                                <div class="post-content">
-                                    {{ post.content.rendered|urlizetrunc_target_blank:30}}
-                                    {% include "forum_conversation/forum_attachments/attachments_images.html" %}
-                                </div>
-
+                            </div>
+                            <div class="col-12 col-lg-11 post-content">
+                                {{ post.content.rendered|urlizetrunc_target_blank:30}}
+                                {% include "forum_conversation/forum_attachments/attachments_images.html" %}
+                            </div>
+                            <div class="col-12 post-content-wrapper">
                                 {% if forloop.first and post.is_topic_head and poll %}
                                     {% include "forum_conversation/forum_polls/poll_detail.html" %}
                                 {% endif %}

--- a/lacommunaute/templates/forum_conversation/topic_list.html
+++ b/lacommunaute/templates/forum_conversation/topic_list.html
@@ -51,7 +51,7 @@
                                             <div class="col-12 post-content-wrapper">
                                                 {%include "forum_conversation/partials/poster.html" with post=topic.first_post%}
                                             </div>
-                                            <div class="col-12 post-content">
+                                            <div class="col-12 col-lg-11 post-content">
                                                 <div id="showmoretopicsarea{{topic.pk}}">
                                                     {{ topic.first_post.content.rendered|urlize|truncatechars:200 }}
                                                     {% if topic.first_post.content.rendered|length > 200 %}

--- a/lacommunaute/templates/forum_member/forum_profile_detail.html
+++ b/lacommunaute/templates/forum_member/forum_profile_detail.html
@@ -37,7 +37,7 @@
                         <div class="card-body">
                             {% for post in recent_posts %}
                                 <div class="row post">
-                                    <div class="col-md-12 post-content-wrapper">
+                                    <div class="col-12 post-content-wrapper">
                                         <div class="post-title">
                                             <a href="{% url 'forum_conversation:topic' post.topic.forum.slug post.topic.forum.pk post.topic.slug post.topic.pk %}?post={{ post.pk }}#{{ post.pk }}"
                                                 class="matomo-event"

--- a/lacommunaute/templates/partials/footer.html
+++ b/lacommunaute/templates/partials/footer.html
@@ -71,7 +71,7 @@
                     <div>
                         <p class="mb-3">
                             Notre mantra issu du Pacte Ambition IAE : Permettre à chacun de trouver sa place.
-                            Libérons notre potentiel d'inclusion pour créer 100 000 emplois de plus.
+                            Libérons notre potentiel d'inclusion pour créer 100&nbsp;000 emplois de plus.
                         </p>
                         <ul>
                             <li><a href="https://emplois.inclusion.beta.gouv.fr" target="_blank" rel="noopener" title="Les emplois (lien externe)">Les emplois</a></li>


### PR DESCRIPTION
## Description

Réduction de largeur de colonne du post-content
https://www.notion.so/Ne-pas-afficher-le-texte-du-sujet-sur-toute-la-largeur-align-avant-le-j-aime-6d1743d78e7c4cdd9d017ce05d562e75

## Type de changement

Modification des class css

### Points d'attention

Et au passage, correction d'un mauvais retour à a ligne dans le texte du footer
