### PR TITLE
Optimisation des requêtes de la vue d'un Forum (aka fil d'actualités d'une communauté)

### DIFF
--- a/config/settings/dev.py
+++ b/config/settings/dev.py
@@ -1,5 +1,8 @@
 import os
 
+# Enable django-debug-toolbar with Docker.
+import socket
+
 from .base import *  # pylint: disable=wildcard-import,unused-wildcard-import # noqa: F403 F401
 
 
@@ -33,9 +36,6 @@ INSTALLED_APPS += ["debug_toolbar"]  # noqa F405
 INTERNAL_IPS = ["127.0.0.1"]
 
 # Enable django-debug-toolbar with Docker.
-import socket
-
-
 _, _, ips = socket.gethostbyname_ex(socket.gethostname())
 INTERNAL_IPS += [ip[:-1] + "1" for ip in ips]
 
@@ -56,6 +56,7 @@ DEBUG_TOOLBAR_CONFIG = {
 
 DATABASES = {
     "default": {
+        "ATOMIC_REQUESTS": True,
         "ENGINE": "django.db.backends.postgresql_psycopg2",
         "HOST": os.getenv("POSTGRESQL_ADDON_HOST"),
         "PORT": os.getenv("POSTGRES_PORT"),

--- a/lacommunaute/templates/forum_conversation/forum_attachments/attachments_detail.html
+++ b/lacommunaute/templates/forum_conversation/forum_attachments/attachments_detail.html
@@ -2,15 +2,9 @@
 {% load forum_permission_tags %}
 {% load attachments_tags %}
 
-{% get_permission 'can_download_files' post.topic.forum request.user as user_can_download_files %}
+{% comment %}'can_download_files' is a forum level permission. It's obtained in parent template to prevent duplicated queries on forum{% endcomment %}
 {% if post.attachments.exists and user_can_download_files %}
     <div class="row attachments mt-3 mt-md-5">
-        {% comment %}
-        <div class="col-md-12">
-            <hr />
-            <p class="h5 mb-0">{% trans "Attachments" %}</p>
-        </div>
-        {% endcomment %}
         {% for attachment in post.attachments.all %}
             {% if not attachment|is_image %}
                 <div class="col-md-12 attachment">

--- a/lacommunaute/templates/forum_conversation/partials/post_feed.html
+++ b/lacommunaute/templates/forum_conversation/partials/post_feed.html
@@ -12,7 +12,7 @@
             <div class="col-12 post-content-wrapper">
                 <div class="d-flex align-items-center mb-1">
                     <span class="mb-0 flex-grow-1">
-                        {%include "forum_conversation/partials/poster.html" with post=post%}
+                        {%include "forum_conversation/partials/poster.html" with post=post topic=topic forum=topic.forum%}
                     </span>
                     {% include "forum_conversation/partials/post_upvotes.html"%}
                 </div>

--- a/lacommunaute/templates/forum_conversation/partials/post_feed.html
+++ b/lacommunaute/templates/forum_conversation/partials/post_feed.html
@@ -4,6 +4,8 @@
 {% load forum_permission_tags %}
 {% load str_filters %}
 
+{% get_permission 'can_download_files' topic.forum request.user as user_can_download_files %}
+
 <div class="card post my-3 bg-light has-links-inside ml-3">
     <div class="card-body">
         <div class="row">
@@ -18,8 +20,7 @@
                     {{ post.content.rendered|urlizetrunc_target_blank:30}}
                     {% include "forum_conversation/forum_attachments/attachments_images.html" %}
                 </div>
-
-                {% include "forum_conversation/forum_attachments/attachments_detail.html" %}
+                {% include "forum_conversation/forum_attachments/attachments_detail.html" with post=post user_can_download_files=user_can_download_files %}
             </div>
         </div>
     </div>

--- a/lacommunaute/templates/forum_conversation/partials/poster.html
+++ b/lacommunaute/templates/forum_conversation/partials/poster.html
@@ -27,6 +27,6 @@
     {% endspaceless %}
     {{post.created|relativetimesince_fr}}
     {% if user_can_edit_post %}
-        &nbsp;<a href="{% if post.is_topic_head %}{% url 'forum_conversation:topic_update' post.topic.forum.slug post.topic.forum.pk post.topic.slug post.topic.pk %}{% else %}{% url 'forum_conversation:post_update' post.topic.forum.slug post.topic.forum.pk post.topic.slug post.topic.pk post.pk %}{% endif %}" title="{% trans "Edit" %}">{% trans "Edit" %}</a>
+        &nbsp;<a href="{% if is_topic_head %}{% url 'forum_conversation:topic_update' forum.slug forum.pk topic.slug topic.pk %}{% else %}{% url 'forum_conversation:post_update' forum.slug forum.pk topic.slug topic.pk post.pk %}{% endif %}" title="{% trans "Edit" %}">{% trans "Edit" %}</a>
     {% endif %}
 </small>

--- a/lacommunaute/templates/forum_conversation/partials/posts_list.html
+++ b/lacommunaute/templates/forum_conversation/partials/posts_list.html
@@ -14,7 +14,7 @@
                     <div class="col-12 post-content-wrapper">
                         <div class="d-flex align-items-center mb-1">
                             <span class="mb-0 flex-grow-1">
-                                {%include "forum_conversation/partials/poster.html" with post=post%}
+                                {%include "forum_conversation/partials/poster.html" with post=post topic=post.topic forum=post.topic.forum%}
                             </span>
                             {% include "forum_conversation/partials/post_upvotes.html"%}
                         </div>

--- a/lacommunaute/templates/forum_conversation/partials/posts_list.html
+++ b/lacommunaute/templates/forum_conversation/partials/posts_list.html
@@ -4,6 +4,8 @@
 {% load forum_permission_tags %}
 {% load str_filters %}
 
+{% get_permission 'can_download_files' topic.forum request.user as user_can_download_files %}
+
 <div id="showmorepostsarea{{topic.pk}}">
     {% for post in posts %}
         <div class="card post mb-3 bg-light has-links-inside ml-3">
@@ -20,9 +22,7 @@
                             {{ post.content.rendered|urlizetrunc_target_blank:30}}
                             {% include "forum_conversation/forum_attachments/attachments_images.html" %}
                         </div>
-
-                        {% include "forum_conversation/forum_attachments/attachments_detail.html" %}
-
+                        {% include "forum_conversation/forum_attachments/attachments_detail.html" with post=post user_can_download_files=user_can_download_files %}
                     </div>
                 </div>
             </div>

--- a/lacommunaute/templates/forum_conversation/topic_detail.html
+++ b/lacommunaute/templates/forum_conversation/topic_detail.html
@@ -5,11 +5,11 @@
 {% load forum_permission_tags %}
 {% load str_filters %}
 
-{% get_permission 'can_download_files' forum request.user as user_can_download_files %}
-
 {% block sub_title %}{{ topic.subject }}{% endblock sub_title %}
 
 {% block content %}
+    {% get_permission 'can_download_files' topic.forum request.user as user_can_download_files %}
+
     <div class="row">
         <div class="col-12">
             <h1>{{ topic.subject }}</h1>
@@ -23,7 +23,7 @@
                         <div class="card-header d-flex align-items-center mb-1">
                             <p class="h4 mb-0 flex-grow-1">
                                 {% if topic.is_locked %}&nbsp;<i class="fas fa-times-circle locked-indicator" title="{% trans 'This topic is locked' %}"></i>{% endif %}
-                                {%include "forum_conversation/partials/poster.html" with post=post%}
+                                {%include "forum_conversation/partials/poster.html" with post=post topic=topic forum=topic.forum is_topic_head=True%}
                             </p>
                             {% block htmx %}
                                 {% include "forum_conversation/partials/topic_likes.html"%}

--- a/lacommunaute/templates/forum_conversation/topic_detail.html
+++ b/lacommunaute/templates/forum_conversation/topic_detail.html
@@ -1,7 +1,11 @@
 {% extends 'board_base.html' %}
+
 {% load i18n %}
 {% load forum_conversation_tags %}
+{% load forum_permission_tags %}
 {% load str_filters %}
+
+{% get_permission 'can_download_files' forum request.user as user_can_download_files %}
 
 {% block sub_title %}{{ topic.subject }}{% endblock sub_title %}
 
@@ -47,7 +51,7 @@
                                     {% include "forum_conversation/forum_polls/poll_detail.html" %}
                                 {% endif %}
 
-                                {% include "forum_conversation/forum_attachments/attachments_detail.html" %}
+                                {% include "forum_conversation/forum_attachments/attachments_detail.html" with post=post user_can_download_files=user_can_download_files%}
 
                                 {% if post.enable_signature and post.poster.forum_profile.signature %}
                                     <div class="post-signature">

--- a/lacommunaute/templates/forum_conversation/topic_list.html
+++ b/lacommunaute/templates/forum_conversation/topic_list.html
@@ -51,7 +51,7 @@
                                     <div class="card-body pt-0">
                                         <div class="row">
                                             <div class="col-12 post-content-wrapper">
-                                                {%include "forum_conversation/partials/poster.html" with post=topic.first_post%}
+                                                {%include "forum_conversation/partials/poster.html" with post=topic.first_post topic=topic forum=forum is_topic_head=True%}
                                             </div>
                                             <div class="col-12 col-lg-11 post-content">
                                                 <div id="showmoretopicsarea{{topic.pk}}">

--- a/lacommunaute/templates/forum_conversation/topic_list.html
+++ b/lacommunaute/templates/forum_conversation/topic_list.html
@@ -5,6 +5,8 @@
 {% load forum_tracking_tags %}
 {% load forum_permission_tags %}
 
+{% get_permission 'can_download_files' forum request.user as user_can_download_files %}
+
 {% if topics or not hide_if_empty %}
     <div class="row mb-3">
         <div class="col-12">
@@ -70,7 +72,7 @@
                                                 </div>
                                                 {% include "forum_conversation/forum_attachments/attachments_images.html" with post=topic.first_post %}
 
-                                                {% include "forum_conversation/forum_attachments/attachments_detail.html" with post=topic.first_post %}
+                                                {% include "forum_conversation/forum_attachments/attachments_detail.html" with post=topic.first_post user_can_download_files=user_can_download_files %}
 
                                                 {% if topic.poll %}
                                                     {% include "forum_conversation/forum_polls/topic_list_poll_detail.html" with poll=topic.poll%}

--- a/lacommunaute/templates/forum_member/subscription_topic_list.html
+++ b/lacommunaute/templates/forum_member/subscription_topic_list.html
@@ -1,0 +1,8 @@
+{% extends "layouts/base.html" %}
+{% load i18n %}
+{% load static %}
+
+
+{% block content %}
+    <a href="{% url 'pages:home' %}">Accueil</a>
+{% endblock content %}

--- a/lacommunaute/www/forum_views/tests_views.py
+++ b/lacommunaute/www/forum_views/tests_views.py
@@ -252,6 +252,12 @@ class ForumViewTest(TestCase):
         self.assertEqual(response.status_code, 200)
         self.assertNotContains(response, f'id="collapsePost{self.topic.pk}')
 
+    def test_queries(self):
+        TopicFactory.create_batch(20, with_post=True)
+        self.client.force_login(self.user)
+        with self.assertNumQueries(28):
+            self.client.get(self.url)
+
 
 class ModeratorEngagementViewTest(TestCase):
     @classmethod

--- a/lacommunaute/www/forum_views/views.py
+++ b/lacommunaute/www/forum_views/views.py
@@ -39,8 +39,15 @@ class ForumView(BaseForumView):
                 "poster",
                 "poster__forum_profile",
                 "first_post",
+                "forum",
             )
-            .prefetch_related("poll", "poll__options", "poll__options__votes", "posts", "posts__attachments")
+            .prefetch_related(
+                "poll",
+                "poll__options",
+                "poll__options__votes",
+                "first_post__attachments",
+                "first_post__poster",
+            )
             .order_by("-last_post_on")
         )
         return qs


### PR DESCRIPTION
## Description

🎸 Obtention de la permission `can_download_files`. Cette permission est gérée au niveau d'un `forum`, il est inutile de la demander pour chaque `attachment`. Cette permission est recupérée en une fois au niveau du template appelant le template `attachments_detail.html`
🎸 Gestion de la donnée `is_topic_head` d'un `post` dans le template `poster`, Cette donnée permet d'aiguiller vers la vue `topic_update` sinon vers la vue `post_update`. Le contexte du template appelant le template `poster.html` permet de déterminer la valeur attendue. Il permet d'éviter des requêtes dupliquées sur `post.is_topic_head`
🎸 Vue `ForumView`, modification du `prefetch_related`, reférence à `first_post` au lieu de `posts` puisque cette vue affiche seulement le premier `post`. Les `posts` suivant sont récupérés par l'appel à la vue `PostListView`. Le template `topic_list.html` accède à `topic.first_post`


## Type de changement

:rocket: optimisations techniques

### Points d'attention

🦺 plus de contexte passé lors de l'appel aux includes
🦺 `first_post` au lieu de `posts` dans le `prefetch_related` de `ForumView`


