### PR TITLE
 Ajout de l'embed de l'enquète Tally "NPS" sur la HP

### DIFF
--- a/lacommunaute/templates/pages/home.html
+++ b/lacommunaute/templates/pages/home.html
@@ -129,7 +129,7 @@
     <script async src="https://tally.so/widgets/embed.js"></script>
     <script>
       window.TallyConfig = {
-        "formId": "mODrpM",
+        "formId": "mVGEr6",
         "popup": {
           "emoji": {
             "text": "👋",

--- a/lacommunaute/templates/pages/home.html
+++ b/lacommunaute/templates/pages/home.html
@@ -123,3 +123,19 @@
         </section>
     {% endif %}
 {% endblock %}
+
+{% block extra_js %}
+    {{ block.super }}
+    <script async src="https://tally.so/widgets/embed.js"></script>
+    <script>
+      window.TallyConfig = {
+        "formId": "mODrpM",
+        "popup": {
+          "emoji": {
+            "text": "👋",
+            "animation": "wave"
+          }
+        }
+      };
+    </script>
+{% endblock %}


### PR DESCRIPTION
## Description

🎸 Ajout de l'embed de l'enquète Tally sur la HP.
Carte notion: https://www.notion.so/plateforme-inclusion/Brancher-le-NPS-du-WP-sur-Django-501ce39fcc8e45e48e5bb2933fd551c0

## Type de changement
Code dans le template

## Remarques
À priori, c'était à ne placer que sur la HP avec un affichage tous les 15 jours.
Cette temporalité n'est pas traitée dans cette PR, ça sera à faire dans un deuxième temps