### PR TITLE
Afficher les likes pour les annonces dans le fil d'actualités d'une communauté

### DIFF
--- a/lacommunaute/www/forum_views/tests_views.py
+++ b/lacommunaute/www/forum_views/tests_views.py
@@ -182,6 +182,22 @@ class ForumViewTest(TestCase):
         self.assertContains(response, '<i class="ri-heart-3-line" aria-hidden="true"></i>')
         self.assertContains(response, "<span>0 J'aime</span>")
 
+    def test_has_liked_TOPIC_ANNOUNCE(self):
+        TopicFactory(forum=self.forum, poster=self.user, with_post=True, with_like=True, type=Topic.TOPIC_ANNOUNCE)
+
+        self.client.force_login(self.user)
+        response = self.client.get(self.url)
+        self.assertContains(response, '<i class="ri-heart-3-fill" aria-hidden="true"></i>')
+        self.assertContains(response, "<span>1 J'aime</span>")
+
+    def test_has_not_liked_TOPIC_ANNOUNCE(self):
+        TopicFactory(forum=self.forum, poster=self.user, with_post=True, type=Topic.TOPIC_ANNOUNCE)
+
+        self.client.force_login(self.user)
+        response = self.client.get(self.url)
+        self.assertContains(response, '<i class="ri-heart-3-line" aria-hidden="true"></i>')
+        self.assertContains(response, "<span>0 J'aime</span>")
+
     def test_anonymous_like(self):
         assign_perm("can_read_forum", AnonymousUser(), self.topic.forum)
         params = {"next_url": self.url}

--- a/lacommunaute/www/forum_views/tests_views.py
+++ b/lacommunaute/www/forum_views/tests_views.py
@@ -277,7 +277,7 @@ class ForumViewTest(TestCase):
     def test_queries(self):
         TopicFactory.create_batch(20, with_post=True)
         self.client.force_login(self.user)
-        with self.assertNumQueries(28):
+        with self.assertNumQueries(29):
             self.client.get(self.url)
 
 

--- a/lacommunaute/www/forum_views/views.py
+++ b/lacommunaute/www/forum_views/views.py
@@ -73,6 +73,19 @@ class ForumView(BaseForumView):
         context["FORUM_NUMBER_POSTS_PER_TOPIC"] = settings.FORUM_NUMBER_POSTS_PER_TOPIC
         context["next_url"] = reverse("forum_extension:forum", kwargs={"pk": forum.pk, "slug": self.forum.slug})
         context["form"] = PostForm(forum=forum, user=self.request.user)
+        context["announces"] = list(
+            self.get_forum()
+            .topics.select_related(
+                "poster",
+                "poster__forum_profile",
+                "first_post",
+                "first_post__poster",
+                "forum",
+            )
+            .filter(type=Topic.TOPIC_ANNOUNCE)
+            .annotate(likes=Count("likers"))
+            .annotate(has_liked=Exists(User.objects.filter(topic_likes=OuterRef("id"), id=self.request.user.id)))
+        )
         return context
 
 


### PR DESCRIPTION
## Description

🎸 Ajout de l'info `has_liked` et du nombre de `like` pour les `topic` de type `ANNONCE` dans le fil d'actualité d'un `forum`

## Type de changement

🪲 Correction de bug (changement non cassant qui corrige un problème).

### Points d'attention

🦺 les `topic` de type `annonce` sont collectés directement dans `get_context_data` et non via le queryset de la `ListView`

### Captures d'écran (optionnel)

![image](https://user-images.githubusercontent.com/11419273/217600025-047ad48f-ac98-438b-aa1b-01d1adb7fb9b.png)

![image](https://user-images.githubusercontent.com/11419273/217600312-8816719f-f1fa-4eb6-9a8f-8d5dfaddd0fc.png)
