### PR TITLE
Compter les Sujets et les Réponses sans limite de profondeur dans les sous communautés

### DIFF
--- a/lacommunaute/www/forum_views/views.py
+++ b/lacommunaute/www/forum_views/views.py
@@ -28,7 +28,7 @@ class IndexView(BaseIndexView):
         """Returns the list of items for this view."""
         return ForumVisibilityContentTree.from_forums(
             self.request.forum_permission_handler.forum_list_filter(
-                Forum.objects.filter(level__lte=1).prefetch_related("members_group__user_set"),
+                Forum.objects.all().prefetch_related("members_group__user_set"),
                 self.request.user,
             ),
         )


### PR DESCRIPTION
## Description

🎸 Selectionner les `forum` sans restriction de niveaux de profondeur pour afficher le nombre de `topic` et de `post` global au niveau du top-level `forum`. L'optimisation n'apporte aucun bénéfice et fausse le comptage des sujets et des réponses

## Type de changement

🎢 Nouvelle fonctionnalité (changement non cassant qui ajoute une fonctionnalité).


### Captures d'écran (optionnel)

top-level-forum : 0 sujet
la bande à itou : 2 sujets
cr rdv mensuel : 3 sujets
espace coconstruction : 6 sujets

Admin View
![image](https://user-images.githubusercontent.com/11419273/217783921-ba8e4ec1-ef5d-436b-95be-a245bccd55b6.png)

IndexView
![image](https://user-images.githubusercontent.com/11419273/217784326-6205afa8-c2c0-424e-be4a-4e64e4744e5f.png)

![image](https://user-images.githubusercontent.com/11419273/217784399-616cdb45-8f3b-493f-a3c4-61c275c76726.png)

ForumView
![image](https://user-images.githubusercontent.com/11419273/217784516-228ad877-4403-46f4-8c7d-7374c2288818.png)

ForumView on subforum
![image](https://user-images.githubusercontent.com/11419273/217784632-b754006f-a85a-4721-bdf1-de6378052471.png)

