### PR TITLE
Page de création de nouvelles communautés publiques avec les bonnes permissions

### DIFF
--- a/lacommunaute/templates/forum/forum_form.html
+++ b/lacommunaute/templates/forum/forum_form.html
@@ -1,0 +1,42 @@
+{% extends "layouts/base.html" %}
+{% load i18n %}
+{% load static %}
+
+{% block sub_title %}New Public Forum{% endblock sub_title %}
+
+{% block breadcrumb %}
+{% endblock %}
+
+{% block content %}
+    <section class="s-title-01">
+        <div class="s-title-01__container container">
+            <div class="s-title-01__row row">
+                <div class="s-title-01__col col-12">
+                    <h1 class="s-title-01__title h1"><strong>Ajouter une nouvelle communauté publique</strong></h1>
+                </div>
+            </div>
+        </div>
+    </section>
+    <section class="s-section">
+        <div class="s-section__container container">
+            <div class="s-section__row row">
+                <div class="s-section__col col-12 col-lg-7">
+                    <div class="c-form">
+                        <form method="post" action="." class="form" enctype="multipart/form-data" novalidate>{% csrf_token %}
+                            {% for error in post_form.non_field_errors %}
+                                <div class="alert alert-danger">
+                                    <i class="icon-exclamation-sign"></i> {{ error }}
+                                </div>
+                            {% endfor %}
+                            {% include "partials/form_field.html" with field=form.name %}
+                            {% include "partials/form_field.html" with field=form.description %}
+                            <div class="form-actions mb-3">
+                                <input type="submit" class="btn btn-primary" value="submit" />
+                            </div>
+                        </form>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </section>
+{% endblock content %}

--- a/lacommunaute/templates/partials/header_nav_primary_items.html
+++ b/lacommunaute/templates/partials/header_nav_primary_items.html
@@ -51,6 +51,9 @@
                             <div class="dropdown-divider"></div>
                         </li>
                         <li>
+                            <a class="dropdown-item text-primary" href="{% url 'forum_extension:create' %}">Nouvelle communauté publique</a>
+                        </li>
+                        <li>
                             <a class="dropdown-item text-primary" href="{% url 'admin:auth_group_changelist' %}">Gérer les groupes</a>
                         </li>
                         <li>

--- a/lacommunaute/www/forum_views/urls.py
+++ b/lacommunaute/www/forum_views/urls.py
@@ -1,6 +1,12 @@
 from django.urls import path
 
-from lacommunaute.www.forum_views.views import ForumView, FunnelView, IndexView, ModeratorEngagementView
+from lacommunaute.www.forum_views.views import (
+    ForumCreateView,
+    ForumView,
+    FunnelView,
+    IndexView,
+    ModeratorEngagementView,
+)
 
 
 app_name = "forum_extension"
@@ -8,6 +14,7 @@ app_name = "forum_extension"
 
 urlpatterns = [
     path("", IndexView.as_view(), name="home"),
+    path("forum/create/", ForumCreateView.as_view(), name="create"),
     path("forum/<str:slug>-<int:pk>/", ForumView.as_view(), name="forum"),
     path("forum/<str:slug>-<int:pk>/engagement", ModeratorEngagementView.as_view(), name="engagement"),
     path("forum/<str:slug>-<int:pk>/funnel", FunnelView.as_view(), name="funnel"),


### PR DESCRIPTION
## Description

🎸 Créer un `forum` avec le `members_group` correspondant, le `group` des moderateurs et les droits associés :  
 * anonyme
 * authentifié
 * membrer
 * animateurs

## Type de changement

🎢 Nouvelle fonctionnalité (changement non cassant qui ajoute une fonctionnalité).

### Points d'attention

🦺 la création des droits pourrait être optimisée


