### PR TITLE
Correction de l'affichage du nombre de sujets et de réponses

### DIFF
--- a/lacommunaute/templates/forum/forum_list.html
+++ b/lacommunaute/templates/forum/forum_list.html
@@ -31,7 +31,9 @@
                             {% if node.obj.is_private%}
                                 <i class="ri-lock-2-fill"></i> {{node.obj.members_group.user_set.count}} membres -
                             {% endif %}
-                            {{node.topics_count}} {% trans "Topics" %} - {{node.posts_count}} {% trans "Posts" %}
+                            {% if node.obj.is_forum %}
+                                {{node.topics_count}} {% trans "Topics" %} - {{node.posts_count}} {% trans "Posts" %}
+                            {% endif %}
                         </p>
                     </div>
                     {% if node.obj in unread_forums %}
@@ -47,7 +49,13 @@
                         {{ node.obj.description.rendered|urlizetrunc_target_blank:30 }}
                     {% endif %}
                     {% if node.children %}
-                        <a data-toggle="collapse" href="#collapse{{node.obj.id}}" role="button" aria-expanded="false" aria-controls="collapse{{node.obj.id}}" class="btn btn-link pt-0 pl-0">Voir les sous-communautés</a>
+                        <a data-toggle="collapse" href="#collapse{{node.obj.id}}" role="button" aria-expanded="false" aria-controls="collapse{{node.obj.id}}" class="btn btn-link pt-0 pl-0">
+                            {% if node.obj.is_forum %}
+                                Voir les sous-communautés
+                            {% else %}
+                                Afficher plus
+                            {% endif %}
+                        </a>
                         <div class="collapse" id="collapse{{node.obj.id}}">
                             <ul class="list-group">
                                 {% for child in node.children  %}
@@ -70,7 +78,9 @@
                                             {% if node.obj.is_private%}
                                                 <i class="ri-lock-2-fill"></i> {{node.obj.members_group.user_set.count}} membres -
                                             {% endif %}
-                                            {{child.topics_count}} {% trans "Topics" %} - {{child.posts_count}} {% trans "Posts" %}
+                                            {% if child.obj.is_forum %}
+                                                {{child.topics_count}} {% trans "Topics" %} - {{child.posts_count}} {% trans "Posts" %}
+                                            {% endif %}
                                         </small>
                                     </li>
                                 {% endfor %}
@@ -102,7 +112,9 @@
                         {% if node.obj.is_private%}
                             <i class="ri-lock-2-fill"></i> {{node.obj.members_group.user_set.count}} membres -
                         {% endif %}
-                        {{node.topics_count}} {% trans "Topics" %} - {{node.posts_count}} {% trans "Posts" %}
+                        {% if node.obj.is_forum %}
+                            {{node.topics_count}} {% trans "Topics" %} - {{node.posts_count}} {% trans "Posts" %}
+                        {% endif %}
                     </small>
                 </li>
             {% endfor %}

--- a/lacommunaute/templates/forum/forum_list.html
+++ b/lacommunaute/templates/forum/forum_list.html
@@ -27,13 +27,8 @@
                                 {{ node.obj.name }}
                             </a>
                         </h3>
-                        <p class="small text-muted mb-2">
-                            {% if node.obj.is_private%}
-                                <i class="ri-lock-2-fill"></i> {{node.obj.members_group.user_set.count}} membres -
-                            {% endif %}
-                            {% if node.obj.is_forum %}
-                                {{node.topics_count}} {% trans "Topics" %} - {{node.posts_count}} {% trans "Posts" %}
-                            {% endif %}
+                        <p class="mb-2">
+                            {% include "forum/partials/topics_and_members_counts.html" %}
                         </p>
                     </div>
                     {% if node.obj in unread_forums %}
@@ -74,14 +69,7 @@
                                                 </span>
                                             {% endif %}
                                         </h4>
-                                        <small class="text-muted">
-                                            {% if node.obj.is_private%}
-                                                <i class="ri-lock-2-fill"></i> {{node.obj.members_group.user_set.count}} membres -
-                                            {% endif %}
-                                            {% if child.obj.is_forum %}
-                                                {{child.topics_count}} {% trans "Topics" %} - {{child.posts_count}} {% trans "Posts" %}
-                                            {% endif %}
-                                        </small>
+                                        {% include "forum/partials/topics_and_members_counts.html" with node=child %}
                                     </li>
                                 {% endfor %}
                             </ul>
@@ -108,14 +96,7 @@
                             </span>
                         {% endif %}
                     </h2>
-                    <small class="text-muted">
-                        {% if node.obj.is_private%}
-                            <i class="ri-lock-2-fill"></i> {{node.obj.members_group.user_set.count}} membres -
-                        {% endif %}
-                        {% if node.obj.is_forum %}
-                            {{node.topics_count}} {% trans "Topics" %} - {{node.posts_count}} {% trans "Posts" %}
-                        {% endif %}
-                    </small>
+                    {% include "forum/partials/topics_and_members_counts.html" %}
                 </li>
             {% endfor %}
         </ul>

--- a/lacommunaute/templates/forum/partials/topics_and_members_counts.html
+++ b/lacommunaute/templates/forum/partials/topics_and_members_counts.html
@@ -1,0 +1,12 @@
+{% load i18n %}
+{% load str_filters %}
+
+<small class="text-muted">
+    {% if node.obj.is_private%}
+        <i class="ri-lock-2-fill"></i> {{node.obj.members_group.user_set.count}} membre{{ node.obj.members_group.user_set.count|pluralizefr }}
+    {% endif %}
+    {% if node.obj.is_forum %}
+        {% if node.obj.is_private%} - {% endif %}
+        {{node.topics_count}} {% trans "Topics" %} - {{node.posts_count}} {% trans "Posts" %}
+    {% endif %}
+</small>


### PR DESCRIPTION
## Description

🎸 Dans les listes des `forum`, afficher le nombre de sujets et de réponses si le `forum` est de type `forum`
🎸 Dans les listes des `forum`, ne pas afficher le nombre de sujets et de réponses si le `forum` est de type `category` ou `link`

## Type de changement

🪲 Correction de bug (changement non cassant qui corrige un problème).

### Captures d'écran (optionnel)

Liste des `forum`
![image](https://user-images.githubusercontent.com/11419273/221831527-fe3ee110-a654-416e-b85e-84e054b7dd46.png)

Détail d'un `forum` avec un sous-forum de type `lien` et un sous-forum de type `forum`
![image](https://user-images.githubusercontent.com/11419273/221831620-f834b5a7-7ad7-48c8-b676-0c75e634de49.png)