### PR TITLE
Filtrer les questions sans réponses

### DIFF
--- a/lacommunaute/forum/models.py
+++ b/lacommunaute/forum/models.py
@@ -5,6 +5,7 @@ from django.contrib.auth.models import Group
 from django.db import models
 from django.db.models.functions import TruncWeek
 from django.utils import timezone
+from django.utils.functional import cached_property
 from machina.apps.forum.abstract_models import AbstractForum
 
 from config.settings.base import DAYS_IN_A_PERIOD
@@ -51,3 +52,13 @@ class Forum(AbstractForum):
             )
         )
         return format_counts_of_objects_for_timeline_chart(datas, period=PeriodAggregation.WEEK)
+
+    @cached_property
+    def count_unanswered_topics(self):
+        return (
+            Topic.objects.exclude(type=Topic.TOPIC_ANNOUNCE)
+            .exclude(approved=False)
+            .exclude(status=Topic.TOPIC_LOCKED)
+            .filter(posts_count=1, forum__in=self.get_descendants(include_self=True))
+            .count()
+        )

--- a/lacommunaute/forum/tests.py
+++ b/lacommunaute/forum/tests.py
@@ -9,6 +9,7 @@ from machina.core.loading import get_class
 from lacommunaute.forum.factories import ForumFactory
 from lacommunaute.forum_conversation.factories import PostFactory, TopicFactory
 from lacommunaute.forum_conversation.forum_polls.factories import TopicPollVoteFactory
+from lacommunaute.forum_conversation.models import Topic
 from lacommunaute.forum_upvote.factories import UpVoteFactory
 
 
@@ -65,3 +66,19 @@ class ForumModelTest(TestCase):
                 "topics": [1],
             },
         )
+
+    def test_count_unanswered_topics(self):
+        forum = ForumFactory()
+
+        TopicFactory(forum=forum, posts_count=0)
+        TopicFactory(forum=forum, posts_count=1)
+        TopicFactory(forum=forum, posts_count=2)
+
+        TopicFactory(forum=forum, posts_count=1, status=Topic.TOPIC_LOCKED)
+        TopicFactory(forum=forum, posts_count=1, type=Topic.TOPIC_ANNOUNCE)
+        TopicFactory(forum=forum, posts_count=1, approved=False)
+
+        subforum = ForumFactory(parent=forum)
+        TopicFactory(forum=subforum, posts_count=1)
+
+        self.assertEqual(forum.count_unanswered_topics, 2)

--- a/lacommunaute/templates/forum/forum_list.html
+++ b/lacommunaute/templates/forum/forum_list.html
@@ -20,7 +20,7 @@
                     <div class="flex-grow-1">
                         <h3 class="h3 mb-0">
                             <a href="{% url 'forum_extension:forum' node.obj.slug node.obj.id %}"
-                                class="stretched-link matomo-event"
+                                class="matomo-event"
                                 data-matomo-category="engagement"
                                 data-matomo-action="view"
                                 data-matomo-option="forum">
@@ -31,13 +31,7 @@
                             {% include "forum/partials/topics_and_members_counts.html" %}
                         </p>
                     </div>
-                    {% if node.obj in unread_forums %}
-                        <div>
-                            <span class="badge badge-pill badge-sm badge-info">
-                                Nouveaux messages
-                            </span>
-                        </div>
-                    {% endif %}
+                    {% include "forum/partials/unanswered_topics_badge.html" %}
                 </div>
                 <div class="card-body pt-0">
                     {%if node.obj.description.rendered%}
@@ -57,17 +51,13 @@
                                     <li class="list-group-item list-group-item-action">
                                         <h4 class="h5 mb-0">
                                             <a href="{% url 'forum_extension:forum' child.obj.slug child.obj.id %}"
-                                                class="stretched-link matomo-event"
+                                                class="matomo-event"
                                                 data-matomo-category="engagement"
                                                 data-matomo-action="view"
                                                 data-matomo-option="forum">
                                                 {{ child.obj.name }}
                                             </a>
-                                            {% if child.obj in unread_forums %}
-                                                <span class="badge badge-pill badge-sm badge-info float-right">
-                                                    Nouveaux messages
-                                                </span>
-                                            {% endif %}
+                                            {% include "forum/partials/unanswered_topics_badge.html" with node=child%}
                                         </h4>
                                         {% include "forum/partials/topics_and_members_counts.html" with node=child %}
                                     </li>
@@ -84,17 +74,13 @@
                 <li class="list-group-item list-group-item-action">
                     <h2 class="h4 mb-0">
                         <a href="{% url 'forum_extension:forum' node.obj.slug node.obj.id %}"
-                            class="stretched-link matomo-event"
+                            class="matomo-event"
                             data-matomo-category="engagement"
                             data-matomo-action="view"
                             data-matomo-option="forum">
                             {{ node.obj.name }}
                         </a>
-                        {% if node.obj in unread_forums %}
-                            <span class="badge badge-pill badge-sm badge-info float-right">
-                                Nouveaux messages
-                            </span>
-                        {% endif %}
+                        {% include "forum/partials/unanswered_topics_badge.html" %}
                     </h2>
                     {% include "forum/partials/topics_and_members_counts.html" %}
                 </li>

--- a/lacommunaute/templates/forum/forum_list.html
+++ b/lacommunaute/templates/forum/forum_list.html
@@ -31,7 +31,9 @@
                             {% include "forum/partials/topics_and_members_counts.html" %}
                         </p>
                     </div>
-                    {% include "forum/partials/unanswered_topics_badge.html" %}
+                    <div>
+                        {% include "forum/partials/unanswered_topics_badge.html" %}
+                    </div>
                 </div>
                 <div class="card-body pt-0">
                     {%if node.obj.description.rendered%}
@@ -48,18 +50,25 @@
                         <div class="collapse" id="collapse{{node.obj.id}}">
                             <ul class="list-group">
                                 {% for child in node.children  %}
-                                    <li class="list-group-item list-group-item-action">
-                                        <h4 class="h5 mb-0">
+                                    <li class="list-group-item list-group-item-action d-flex">
+                                        <div class="flex-grow-1">
                                             <a href="{% url 'forum_extension:forum' child.obj.slug child.obj.id %}"
-                                                class="matomo-event"
+                                                class="h5 d-block mb-0 matomo-event"
                                                 data-matomo-category="engagement"
                                                 data-matomo-action="view"
                                                 data-matomo-option="forum">
                                                 {{ child.obj.name }}
                                             </a>
+                                            <small class="text-muted">
+                                                {% if node.obj.is_private%}
+                                                    <i class="ri-lock-2-fill"></i> {{node.obj.members_group.user_set.count}} membres -
+                                                {% endif %}
+                                                {{child.topics_count}} {% trans "Topics" %} - {{child.posts_count}} {% trans "Posts" %}
+                                            </small>
+                                        </div>
+                                        <div>
                                             {% include "forum/partials/unanswered_topics_badge.html" with node=child%}
-                                        </h4>
-                                        {% include "forum/partials/topics_and_members_counts.html" with node=child %}
+                                        </div>
                                     </li>
                                 {% endfor %}
                             </ul>
@@ -71,18 +80,25 @@
     {% else %}
         <ul class="list-group mb-3 mb-md-5">
             {% for node in forum_contents.top_nodes %}
-                <li class="list-group-item list-group-item-action">
-                    <h2 class="h4 mb-0">
+                <li class="list-group-item list-group-item-action d-flex">
+                    <div class="flex-grow-1">
                         <a href="{% url 'forum_extension:forum' node.obj.slug node.obj.id %}"
-                            class="matomo-event"
+                            class="matomo-event h4 d-block mb-0"
                             data-matomo-category="engagement"
                             data-matomo-action="view"
                             data-matomo-option="forum">
                             {{ node.obj.name }}
                         </a>
+                        <small class="text-muted">
+                            {% if node.obj.is_private%}
+                                <i class="ri-lock-2-fill"></i> {{node.obj.members_group.user_set.count}} membres -
+                            {% endif %}
+                            {{node.topics_count}} {% trans "Topics" %} - {{node.posts_count}} {% trans "Posts" %}
+                        </small>
+                    </div>
+                    <div>
                         {% include "forum/partials/unanswered_topics_badge.html" %}
-                    </h2>
-                    {% include "forum/partials/topics_and_members_counts.html" %}
+                    </div>
                 </li>
             {% endfor %}
         </ul>

--- a/lacommunaute/templates/forum/partials/unanswered_topics_badge.html
+++ b/lacommunaute/templates/forum/partials/unanswered_topics_badge.html
@@ -2,13 +2,10 @@
 
 {% if node.obj.count_unanswered_topics > 0 %}
     <a href="{% url 'forum_extension:forum' node.obj.slug node.obj.id %}?new=1"
-        class="matomo-event text-white float-right"
+        class="matomo-event badge badge-xs badge-pill badge-communaute text-white text-decoration-none"
         data-matomo-category="engagement"
         data-matomo-action="view"
         data-matomo-option="unanswered">
-        <span class="badge badge-sm badge-pill badge-communaute text-white ml-0 ml-lg-2 mt-1 mt-lg-0">
-            <i class="ri-group-line"></i>
-            {{node.obj.count_unanswered_topics}} nouvelle{{ node.obj.count_unanswered_topics|pluralizefr }} question{{ node.obj.count_unanswered_topics|pluralizefr }}
-        </span>
+        {{node.obj.count_unanswered_topics}} nouvelle{{ node.obj.count_unanswered_topics|pluralizefr }} question{{ node.obj.count_unanswered_topics|pluralizefr }}
     </a>
 {% endif %}

--- a/lacommunaute/templates/forum/partials/unanswered_topics_badge.html
+++ b/lacommunaute/templates/forum/partials/unanswered_topics_badge.html
@@ -1,0 +1,14 @@
+{% load str_filters %}
+
+{% if node.obj.count_unanswered_topics > 0 %}
+    <a href="{% url 'forum_extension:forum' node.obj.slug node.obj.id %}?new=1"
+        class="matomo-event text-white float-right"
+        data-matomo-category="engagement"
+        data-matomo-action="view"
+        data-matomo-option="unanswered">
+        <span class="badge badge-sm badge-pill badge-communaute text-white ml-0 ml-lg-2 mt-1 mt-lg-0">
+            <i class="ri-group-line"></i>
+            {{node.obj.count_unanswered_topics}} nouvelle{{ node.obj.count_unanswered_topics|pluralizefr }} question{{ node.obj.count_unanswered_topics|pluralizefr }}
+        </span>
+    </a>
+{% endif %}

--- a/lacommunaute/www/forum_views/tests_views.py
+++ b/lacommunaute/www/forum_views/tests_views.py
@@ -280,6 +280,19 @@ class ForumViewTest(TestCase):
         with self.assertNumQueries(29):
             self.client.get(self.url)
 
+    def test_param_new_in_request(self):
+        topic_with_2_posts = TopicFactory(with_post=True, forum=self.forum)
+        topic_is_locked = TopicFactory(with_post=True, forum=self.forum, status=Topic.TOPIC_LOCKED)
+        PostFactory(topic=topic_with_2_posts)
+        self.client.force_login(self.user)
+
+        response = self.client.get(self.url + "?new=1")
+
+        self.assertEqual(response.status_code, 200)
+        self.assertIn(self.topic, response.context_data["topics"])
+        self.assertNotIn(topic_with_2_posts, response.context_data["topics"])
+        self.assertNotIn(topic_is_locked, response.context_data["topics"])
+
 
 class ModeratorEngagementViewTest(TestCase):
     @classmethod

--- a/lacommunaute/www/forum_views/views.py
+++ b/lacommunaute/www/forum_views/views.py
@@ -65,6 +65,10 @@ class ForumView(BaseForumView):
             )
             .order_by("-last_post_on")
         )
+
+        if self.request.GET.get("new", None):
+            qs = qs.filter(posts_count=1).exclude(status=Topic.TOPIC_LOCKED)
+
         return qs
 
     def get_context_data(self, **kwargs):


### PR DESCRIPTION
## Description

🎸 afficher le nombre de sujets non répondus dans la liste de `forum`
🎸 filtrer les `topic` non répondus de le fil d'actualités d'un `forum`

## Type de changement

🎢 Nouvelle fonctionnalité (changement non cassant qui ajoute une fonctionnalité).

### Points d'attention

🦺 vérifier si la méthode `count_unanswered_topics` ne génère pas de requêtes en N+1

### Captures d'écran (optionnel)

Liste des forums 
![image](https://user-images.githubusercontent.com/11419273/222080501-b5b213bd-281a-4109-9ccc-a1bcc49ce633.png)

Fil d'actualités d'un forum
![image](https://user-images.githubusercontent.com/11419273/222080609-8e552cbc-0c74-4faa-9934-0806ede70bcb.png)

Topics non répondus d'un forum sans sous-forum
![image](https://user-images.githubusercontent.com/11419273/222080739-3ff4ca08-0c1c-4649-9dc5-e3bf8c28c21c.png)

Topic non répondu d'un forum avec sous-forums
![image](https://user-images.githubusercontent.com/11419273/222080917-151cb148-37a1-4909-8e01-d9701b289d6a.png)

