### PR TITLE
Nettoyage des Formulaires de creation/mise à jour des Topic & Post

### DIFF
--- a/lacommunaute/templates/forum_conversation/partials/post_form.html
+++ b/lacommunaute/templates/forum_conversation/partials/post_form.html
@@ -18,7 +18,6 @@
 <!-- Sub "forms" tabs -->
 {% if attachment_formset %}
     <ul class="nav nav-tabs nav-tabs--communaute">
-        <li class="nav-item"><a href="#options" class="nav-link active" data-toggle="tab">{% trans "Options" %}</a></li>
         <li class="nav-item"><a href="#attachments" class="nav-link" data-toggle="tab">{% trans "Attachments" %}</a></li>
     </ul>
 {% endif %}

--- a/lacommunaute/templates/forum_conversation/partials/topic_form.html
+++ b/lacommunaute/templates/forum_conversation/partials/topic_form.html
@@ -20,9 +20,8 @@
     <!-- Sub "forms" tabs -->
     {% if poll_option_formset or attachment_formset %}
         <ul class="nav nav-tabs nav-tabs--communaute border-bottom-0">
-            <li class="nav-item"><a href="#options" class="nav-link active" data-toggle="tab">{% trans "Options" %}</a></li>
-            {% if poll_option_formset %}<li class="nav-item"><a href="#poll" class="nav-link" data-toggle="tab">{% trans "Poll" %}</a></li>{% endif %}
             {% if attachment_formset %}<li class="nav-item"><a href="#attachments" class="nav-link" data-toggle="tab">{% trans "Attachments" %}</a></li>{% endif %}
+            {% if poll_option_formset %}<li class="nav-item"><a href="#poll" class="nav-link" data-toggle="tab">{% trans "Poll" %}</a></li>{% endif %}
         </ul>
     {% endif %}
 
@@ -40,8 +39,6 @@
                                 </div>
                             {% endwith %}
                         </div>
-                    {% else %}
-                        <p>Aucune option</p>
                     {% endif %}
                 </div>
             </div>
@@ -87,9 +84,6 @@
     </div>
     <hr class="mb-5">
     <div class="form-actions form-row">
-        <div class="form-group col-auto">
-            <input type="submit" name="preview" class="btn btn-outline-primary" value="{% trans "Preview" %}" />
-        </div>
         <div class="form-group col-auto">
             <input type="submit" class="btn btn-primary matomo-event" value="{% trans "Submit" %}"
                 data-matomo-category="engagement"

--- a/lacommunaute/templates/forum_conversation/post_update.html
+++ b/lacommunaute/templates/forum_conversation/post_update.html
@@ -11,9 +11,6 @@
             <h1>{{ topic.subject }}</h1>
         </div>
     </div>
-    {% if preview %}
-        {% include "forum_conversation/post_preview.html" %}
-    {% endif %}
     <div class="row">
         <div class="col-12">
             <div class="card post-edit">
@@ -24,9 +21,6 @@
                     <form method="post" action="." class="form" enctype="multipart/form-data" novalidate>{% csrf_token %}
                         {% include "forum_conversation/partials/post_form.html" %}
                         <div class="form-actions form-row">
-                            <div class="form-group col-auto">
-                                <input type="submit" name="preview" class="btn btn-outline-primary" value="{% trans "Preview" %}" />
-                            </div>
                             <div class="form-group col-auto">
                                 <input type="submit" class="btn btn-primary" value="{% trans "Submit" %}" />
                             </div>

--- a/lacommunaute/templates/forum_conversation/topic_create.html
+++ b/lacommunaute/templates/forum_conversation/topic_create.html
@@ -13,9 +13,6 @@
     {% if poll_preview %}
         {% include "forum_conversation/forum_polls/poll_preview.html" %}
     {% endif %}
-    {% if preview %}
-        {% include "forum_conversation/post_preview.html" %}
-    {% endif %}
     <div class="row">
         <div class="col-12">
             <div class="card post-edit">


### PR DESCRIPTION
## Description

🎸 Suppression de la prévisualisation : pas de valeur ajoutée et source de bugs
🎸 Suppression du `nav-tab options` 

## Type de changement

🎨 UI

### Captures d'écran (optionnel)

Nouveau `Topic`
![image](https://user-images.githubusercontent.com/11419273/223389681-c1c581d3-5ff6-45bc-979a-207e54f5aaba.png)

Nouveau `Topic` avec `Attachment`
![image](https://user-images.githubusercontent.com/11419273/223389812-142840fc-6dda-4f93-9086-ad5826f2f85f.png)

Édition du `Topic`
![image](https://user-images.githubusercontent.com/11419273/223390031-afb39b16-dfd0-47b3-ba2c-ed5ef80ba943.png)


Edition du `Post`
![image](https://user-images.githubusercontent.com/11419273/223389422-f4825b91-e5e7-46f1-bc17-e8613e96b821.png)
