### PR TITLE
Automatisation de la collecte des stats quotidiennes

### DIFF
--- a/lacommunaute/forum_stats/management/commands/collect_daily_matomo_stats.py
+++ b/lacommunaute/forum_stats/management/commands/collect_daily_matomo_stats.py
@@ -1,0 +1,20 @@
+from datetime import date
+
+from dateutil.relativedelta import relativedelta
+from django.core.management.base import BaseCommand
+
+from lacommunaute.forum_stats.models import Stat
+from lacommunaute.utils.matomo import collect_stats_from_matomo_api
+
+
+class Command(BaseCommand):
+    help = "Collecter les stats journalieres matomo, jusqu'à la veille de l'execution"
+
+    def handle(self, *args, **options):
+
+        from_date = Stat.objects.filter(period="day").order_by("-date").first().date + relativedelta(days=1)
+        to_date = date.today() - relativedelta(days=1)
+
+        collect_stats_from_matomo_api(from_date=from_date, to_date=to_date)
+
+        self.stdout.write(self.style.SUCCESS("That's all, folks!"))


### PR DESCRIPTION
## Description

🎸 Mise en place de la management command pour automatiser la collecte des stats quotidiennes depuis matomo

## Type de changement

🎢 Nouvelle fonctionnalité (changement non cassant qui ajoute une fonctionnalité).
🚧 technique

### Points d'attention

🦺 collecte les stats à partir du lendemain de la date de derniere collecte
🦺 collecte les stats jusqu'à la veille du traitement
🦺 management command appelée par une tâche cron
