### PR TITLE
Montrer le popup Tally maximum une fois toutes les deux semaines

### DIFF
--- a/lacommunaute/templates/pages/home.html
+++ b/lacommunaute/templates/pages/home.html
@@ -127,18 +127,59 @@
 {% block extra_js %}
     {{ block.super }}
     <script async src="https://tally.so/widgets/embed.js"></script>
-    <script>
-        window.TallyConfig = {
-            "formId": "mVGEr6",
-            "popup": {
-                "emoji": {
-                    "text": "👋",
-                    "animation": "wave"
-                },
-                "autoClose": 3000,
-                "showOnce": true,
-                "doNotShowAfterSubmit": true
+    <script defer>
+        // Any given Tally popup will not be shown more than once every `minDaysBetweenDisplays` days.
+        const minDaysBetweenDisplays = 14;
+        const delayBeforeShowingPopupInSeconds = 45;
+        const formId = 'mVGEr6';
+        const key = 'statsTallyPopupLastShown-' + formId;
+        const todaysDate = new Date();
+
+        function supportsLocalStorage() {
+            try {
+                return 'localStorage' in window && window['localStorage'] !== null;
+            } catch (e) {
+                return false;
             }
+        };
+
+        function stopShowingPopupForAWhile() {
+            localStorage.setItem(key, JSON.stringify(todaysDate));
+        }
+
+        function displayTallyPopup() {
+            window.Tally.openPopup(formId, {
+                emoji: {
+                    text: "👋",
+                    animation: "wave"
+                },
+                onClose: () => {
+                    stopShowingPopupForAWhile();
+                },
+                onSubmit: () => {
+                    stopShowingPopupForAWhile();
+                }
+            });
+        };
+
+        function shouldDisplayTallyPopup() {
+            if (!supportsLocalStorage()) {
+                return true;
+            }
+            infoKey = localStorage.getItem(key);
+            if (infoKey) {
+                const lastShown = Date.parse(JSON.parse(localStorage.getItem(key)));
+                const milliSecondsElapsed = todaysDate - lastShown;
+                const daysElapsed = milliSecondsElapsed / (1000 * 3600 * 24);
+                if (daysElapsed <= minDaysBetweenDisplays) {
+                    return false;
+                };
+            };
+            return true;
+        };
+
+        if (shouldDisplayTallyPopup()) {
+            setTimeout(displayTallyPopup, delayBeforeShowingPopupInSeconds * 1000);
         };
     </script>
 {% endblock %}


### PR DESCRIPTION
## Description
cf titre

## Type de changement
Le popup cesse de s'afficher pendant 14 jours à partir du moment où soit 
- l'utilisateur ferme manuellement le popup en cliquant sur la croix en haut à droite, soit 
- l'utilisateur soumet le formulaire. 

Tant que l'utilisateur n'a fait aucune de ces deux actions on continue d'afficher le popup.

### Points d'attention
La popup s'affiche au bout de 45 secondes (préférence du C2) mais ça peut être changé si vous préférez un affichage plus rapide (`const delayBeforeShowingPopupInSeconds = 45;`)

Pour annuler le masquage des 15 jours, il faut aller dans le localStorage de la console du navigateur et supprimer l'entrée "statsTallyPopupLastShown-mVGEr6"
![capture 2023-03-13 à 11 20 52](https://user-images.githubusercontent.com/3874024/224674089-81443f51-f4b8-4a22-8744-14d28c11ae2a.png)

