### PR TITLE
CRON : mise en place de la collecte automatique des stats quotidiennes matomo

### DIFF
--- a/clevercloud/collect_daily_matomo_stats.sh
+++ b/clevercloud/collect_daily_matomo_stats.sh
@@ -1,0 +1,18 @@
+#!/bin/bash -l
+
+# Collect Daily Matomo Stats
+
+#
+# About clever cloud cronjobs:
+# https://www.clever-cloud.com/doc/tools/crons/
+#
+
+if [[ "$INSTANCE_NUMBER" != "0" ]]; then
+    echo "Instance number is ${INSTANCE_NUMBER}. Stop here."
+    exit 0
+fi
+
+# $APP_HOME is set by default by clever cloud.
+cd $APP_HOME
+
+python manage.py collect_daily_matomo_stats

--- a/clevercloud/cron.json
+++ b/clevercloud/cron.json
@@ -1,0 +1,3 @@
+[
+    "0 5 * * * $ROOT/clevercloud/collect_daily_matomo_stats.sh"
+]


### PR DESCRIPTION
## Description

🎸 automatiser la collecte des stats matomo via une `management command`, executée par une tâche `cron`
🎸 tâche executée tous les jours à 5h

## Type de changement

🚧 technique

### Points d'attention

🦺 script sh de lancement de la management command dans le repertoire `clevercloud/`
🦺 cronjob standard paramétré dans le fichier `clevercloud/cron.json`

