### PR TITLE
Abonnement - suppression du code mort

### DIFF
--- a/lacommunaute/templates/forum_conversation/partials/topic_detail_actions.html
+++ b/lacommunaute/templates/forum_conversation/partials/topic_detail_actions.html
@@ -2,8 +2,6 @@
 {% load forum_permission_tags %}
 
 {% get_permission 'can_add_post' topic request.user as user_can_add_post %}
-{% comment %}{% get_permission 'can_subscribe_to_topic' topic request.user as user_can_subscribe_to_topic %}
-{% get_permission 'can_unsubscribe_from_topic' topic request.user as user_can_unsubscribe_from_topic %} {% endcomment %}
 {% get_permission 'can_lock_topics' topic.forum request.user as user_can_lock_topics %}
 {% get_permission 'can_move_topics' topic.forum request.user as user_can_move_topics %}
 {% get_permission 'can_delete_topics' topic.forum request.user as user_can_delete_topics %}
@@ -42,11 +40,6 @@
     </a>
 {% endif %}
 
-{% if user_can_subscribe_to_topic %}
-    <a href="{% url 'members:topic_subscribe' topic.pk %}" class="btn btn-info btn-sm btn-subscription"><i class="fas fa-check">&nbsp;</i>{% trans "Subscribe" %}</a>
-{% elif user_can_unsubscribe_from_topic %}
-    <a href="{% url 'members:topic_unsubscribe' topic.pk %}" class="btn btn-info btn-sm btn-subscription"><i class="fas fa-times">&nbsp;</i>{% trans "Unsubscribe" %}</a>
-{% endif %}
 {% if user_can_lock_topics and not topic.is_locked or user_can_move_topics or user_can_delete_topics %}
     <button id="id_dropdown_moderation_menu_button" class="btn btn-outline-primary btn-ico-only btn-sm" type="button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
         <i class="ri-more-line" aria-label="Plus d'actions"></i>

--- a/lacommunaute/templates/forum_member/subscription_topic_list.html
+++ b/lacommunaute/templates/forum_member/subscription_topic_list.html
@@ -1,8 +1,0 @@
-{% extends "layouts/base.html" %}
-{% load i18n %}
-{% load static %}
-
-
-{% block content %}
-    <a href="{% url 'forum_extension:home' %}">Accueil</a>
-{% endblock content %}

--- a/lacommunaute/www/forum_member_views/tests.py
+++ b/lacommunaute/www/forum_member_views/tests.py
@@ -1,5 +1,4 @@
 import uuid
-from unittest import mock
 
 from django.contrib.auth.models import Group
 from django.test import RequestFactory, TestCase
@@ -7,7 +6,6 @@ from django.urls import reverse
 from machina.core.loading import get_class
 from machina.test.factories.forum import create_forum
 
-from lacommunaute.forum_conversation.factories import TopicFactory
 from lacommunaute.forum_member.factories import ForumProfileFactory
 from lacommunaute.users.factories import DEFAULT_PASSWORD, UserFactory
 from lacommunaute.www.forum_member_views.views import ForumProfileUpdateView
@@ -168,36 +166,3 @@ class JoinForumFormViewTest(TestCase):
         self.client.force_login(self.user)
         self.client.post(self.url)
         self.assertTrue(self.forum.members_group.user_set.filter(id=self.user.id).exists())
-
-
-@mock.patch(
-    "lacommunaute.www.forum_member_views.views.TopicSubscribeView.perform_permissions_check", return_value=True
-)
-class TopicSubscribeViewTest(TestCase):
-    def test_authentified_access(self, _mock):
-        topic = TopicFactory(with_post=True)
-        url = reverse("members:topic_subscribe", kwargs={"pk": topic.pk})
-
-        self.client.force_login(topic.poster)
-        response = self.client.get(url)
-        self.assertEqual(response.status_code, 200)
-
-
-@mock.patch(
-    "lacommunaute.www.forum_member_views.views.TopicUnsubscribeView.perform_permissions_check", return_value=True
-)
-class TopicUnsubscribeViewTest(TestCase):
-    def test_authentified_access(self, _mock):
-        topic = TopicFactory(with_post=True)
-        url = reverse("members:topic_unsubscribe", kwargs={"pk": topic.pk})
-
-        self.client.force_login(topic.poster)
-        response = self.client.get(url)
-        self.assertEqual(response.status_code, 200)
-
-
-class TopicSubscriptionListViewTest(TestCase):
-    def test_access(self):
-        self.client.force_login(UserFactory())
-        response = self.client.get(reverse("members:user_subscriptions"))
-        self.assertEqual(response.status_code, 200)

--- a/lacommunaute/www/forum_member_views/urls.py
+++ b/lacommunaute/www/forum_member_views/urls.py
@@ -6,9 +6,6 @@ from lacommunaute.www.forum_member_views.views import (
     JoinForumFormView,
     JoinForumLandingView,
     ModeratorProfileListView,
-    TopicSubscribeView,
-    TopicSubscriptionListView,
-    TopicUnsubscribeView,
 )
 
 
@@ -20,7 +17,4 @@ urlpatterns = [
     path("forum/<str:slug>-<int:pk>/", ModeratorProfileListView.as_view(), name="forum_profiles"),
     path("join-forum-landing/<uuid:token>/", JoinForumLandingView.as_view(), name="join_forum_landing"),
     path("join-forum/<uuid:token>/", JoinForumFormView.as_view(), name="join_forum_form"),
-    path("topic/<int:pk>/subscribe/", TopicSubscribeView.as_view(), name="topic_subscribe"),
-    path("topic/<int:pk>/unsubscribe/", TopicUnsubscribeView.as_view(), name="topic_unsubscribe"),
-    path("subscriptions/", TopicSubscriptionListView.as_view(), name="user_subscriptions"),
 ]

--- a/lacommunaute/www/forum_member_views/views.py
+++ b/lacommunaute/www/forum_member_views/views.py
@@ -8,9 +8,6 @@ from django.views.generic import FormView, ListView, TemplateView
 from machina.apps.forum_member.views import (
     ForumProfileDetailView as BaseForumProfileDetailView,
     ForumProfileUpdateView as BaseForumProfileUpdateView,
-    TopicSubscribeView as BaseTopicSubscribeView,
-    TopicSubscriptionListView as BaseTopicSubscriptionListView,
-    TopicUnsubscribeView as BaseTopicUnsubscribeView,
 )
 from machina.core.loading import get_class
 
@@ -134,15 +131,3 @@ class JoinForumFormView(LoginRequiredMixin, FormView):
                 "pk": self.forum.pk,
             },
         )
-
-
-class TopicSubscribeView(BaseTopicSubscribeView):
-    pass
-
-
-class TopicUnsubscribeView(BaseTopicUnsubscribeView):
-    pass
-
-
-class TopicSubscriptionListView(BaseTopicSubscriptionListView):
-    pass

--- a/lacommunaute/www/forum_views/tests_views.py
+++ b/lacommunaute/www/forum_views/tests_views.py
@@ -96,33 +96,6 @@ class ForumViewTest(TestCase):
 
         cls.url = reverse("forum_extension:forum", kwargs={"pk": cls.forum.pk, "slug": cls.forum.slug})
 
-    def test_subscription_button_is_hidden(self):
-        self.client.force_login(self.user)
-        response = self.client.get(self.url)
-
-        self.assertEqual(response.status_code, 200)
-        self.assertContains(
-            response,
-            reverse(
-                "forum_conversation_extension:post_create",
-                kwargs={
-                    "forum_pk": self.forum.pk,
-                    "forum_slug": self.forum.slug,
-                    "pk": self.topic.pk,
-                    "slug": self.topic.slug,
-                },
-            ),
-        )
-        self.assertNotContains(
-            response,
-            reverse(
-                "members:topic_subscribe",
-                kwargs={
-                    "pk": self.topic.pk,
-                },
-            ),
-        )
-
     def test_show_comments(self):
         topic_url = reverse(
             "forum_conversation_extension:showmore_posts",


### PR DESCRIPTION
## Description

🎸 Suppression du code surchargé, lié aux fonctionnalités d'abonnement, pour éviter les confusions avec la gestion des notifications basées sur les Likes à venir


## Type de changement

🚧 technique
