### PR TITLE
CRON : automatisation des notifications sur la première reponse

### DIFF
--- a/clevercloud/cron.json
+++ b/clevercloud/cron.json
@@ -1,3 +1,4 @@
 [
-    "0 5 * * * $ROOT/clevercloud/collect_daily_matomo_stats.sh"
+    "0 5 * * * $ROOT/clevercloud/collect_daily_matomo_stats.sh",
+    "5 7-21 * * * $ROOT/clevercloud/send_notifs_when_first_reply.sh"
 ]

--- a/clevercloud/send_notifs_when_first_reply.sh
+++ b/clevercloud/send_notifs_when_first_reply.sh
@@ -1,0 +1,18 @@
+#!/bin/bash -l
+
+# Collect Daily Matomo Stats
+
+#
+# About clever cloud cronjobs:
+# https://www.clever-cloud.com/doc/tools/crons/
+#
+
+if [[ "$INSTANCE_NUMBER" != "0" ]]; then
+    echo "Instance number is ${INSTANCE_NUMBER}. Stop here."
+    exit 0
+fi
+
+# $APP_HOME is set by default by clever cloud.
+cd $APP_HOME
+
+python manage.py send_notifs_when_first_reply


### PR DESCRIPTION
## Description

🎸 Executer la `management command` `send_notifs_when_first_reply` , tous les jours, 1 fois par heure entre 7h et 21h

## Type de changement

🎢 Nouvelle fonctionnalité (changement non cassant qui ajoute une fonctionnalité).
🚧 technique


