### PR TITLE
Notification : ajout *par lot* des nouveaux utilisateurs dans la sequence d'onboarding 

### DIFF
--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -321,7 +321,7 @@ MATOMO_URL = "https://stats.data.gouv.fr/index.php"
 # ---------------------------------------
 SIB_URL = "https://api.sendinblue.com/v3/"
 SIB_SMTP_URL = os.path.join(SIB_URL, "smtp/email")
-SIB_CONTACTS_URL = os.path.join(SIB_URL, "contacts")
+SIB_CONTACTS_URL = os.path.join(SIB_URL, "contacts/import")
 
 SIB_API_KEY = os.getenv("SIB_API_KEY", "set-sib-api-key")
 DEFAULT_FROM_EMAIL = os.getenv("DEFAULT_FROM_EMAIL", "noreply@inclusion.beta.gouv.fr")

--- a/lacommunaute/notification/emails.py
+++ b/lacommunaute/notification/emails.py
@@ -26,17 +26,16 @@ def send_email(to, params, template_id):
     )
 
 
-def add_user_to_list(email, firstname, lastname, list_id):
+def bulk_send_user_to_list(users, list_id):
     payload = {
-        "email": email,
-        "attributes": {
-            "FNAME": firstname,
-            "LNAME": lastname,
-        },
-        "emailBlacklisted": False,
-        "smsBlacklisted": False,
+        "jsonBody": [
+            {"email": user.email, "attributes": {"NOM": user.last_name, "PRENOM": user.first_name}} for user in users
+        ],
+        "emailBlacklist": False,
+        "smsBlacklist": False,
         "listIds": [list_id],
-        "updateEnabled": True,
+        "updateExistingContacts": True,
+        "emptyContactsAttributes": True,
     }
     headers = {"accept": "application/json", "content-type": "application/json", "api-key": SIB_API_KEY}
     response = httpx.post(SIB_CONTACTS_URL, headers=headers, json=payload)

--- a/lacommunaute/notification/tasks.py
+++ b/lacommunaute/notification/tasks.py
@@ -1,5 +1,5 @@
 from config.settings.base import SIB_FIRST_REPLY_TEMPLATE, SIB_ONBOARDING_LIST
-from lacommunaute.notification.emails import add_user_to_list, send_email
+from lacommunaute.notification.emails import bulk_send_user_to_list, send_email
 from lacommunaute.notification.utils import collect_first_replies, collect_new_users_for_onboarding
 
 
@@ -17,6 +17,4 @@ def send_notifs_when_first_reply():
 
 
 def add_user_to_list_when_register():
-
-    for email, first_name, last_name in collect_new_users_for_onboarding():
-        add_user_to_list(email, first_name, last_name, SIB_ONBOARDING_LIST)
+    bulk_send_user_to_list(collect_new_users_for_onboarding(), SIB_ONBOARDING_LIST)

--- a/lacommunaute/notification/tests/tests_tasks.py
+++ b/lacommunaute/notification/tests/tests_tasks.py
@@ -57,18 +57,18 @@ class AddUserToListWhenRegister(TestCase):
 
     @respx.mock
     def test_add_user_to_list_when_register(self):
-        user = UserFactory()
+        users = UserFactory.create_batch(3)
 
         payload = {
-            "email": user.email,
-            "attributes": {
-                "FNAME": user.first_name,
-                "LNAME": user.last_name,
-            },
-            "emailBlacklisted": False,
-            "smsBlacklisted": False,
+            "jsonBody": [
+                {"email": user.email, "attributes": {"NOM": user.last_name, "PRENOM": user.first_name}}
+                for user in users
+            ],
+            "emailBlacklist": False,
+            "smsBlacklist": False,
             "listIds": [SIB_ONBOARDING_LIST],
-            "updateEnabled": True,
+            "updateExistingContacts": True,
+            "emptyContactsAttributes": True,
         }
         add_user_to_list_when_register()
 

--- a/lacommunaute/notification/tests/tests_utils.py
+++ b/lacommunaute/notification/tests/tests_utils.py
@@ -6,6 +6,7 @@ from lacommunaute.notification.factories import EmailSentTrackFactory
 from lacommunaute.notification.models import EmailSentTrack
 from lacommunaute.notification.utils import collect_first_replies, collect_new_users_for_onboarding, last_notification
 from lacommunaute.users.factories import UserFactory
+from lacommunaute.users.models import User
 
 
 class LastNotificationTestCase(TestCase):
@@ -74,13 +75,13 @@ class CollectFirstRepliesTestCase(TestCase):
 
 class CollectNewUsersForOnBoardingTestCase(TestCase):
     def test_no_onboarding_notification_ever(self):
-        user = UserFactory()
-        self.assertEqual(collect_new_users_for_onboarding(), [(user.email, user.first_name, user.last_name)])
+        UserFactory()
+        self.assertEqual(list(collect_new_users_for_onboarding()), list(User.objects.all()))
 
     def test_user_against_last_notification(self):
         EmailSentTrackFactory(kind="onboarding")
-        user = UserFactory()
-        self.assertEqual(collect_new_users_for_onboarding(), [(user.email, user.first_name, user.last_name)])
+        UserFactory()
+        self.assertEqual(list(collect_new_users_for_onboarding()), list(User.objects.all()))
 
         EmailSentTrackFactory(kind="onboarding")
         self.assertEqual(len(collect_new_users_for_onboarding()), 0)
@@ -88,7 +89,7 @@ class CollectNewUsersForOnBoardingTestCase(TestCase):
     def test_last_emailsenttrack_with_kind(self):
         UserFactory()
         EmailSentTrackFactory(kind="first_reply")
-        self.assertEqual(len(collect_new_users_for_onboarding()), 1)
+        self.assertEqual(list(collect_new_users_for_onboarding()), list(User.objects.all()))
 
         EmailSentTrackFactory(kind="onboarding")
         self.assertEqual(len(collect_new_users_for_onboarding()), 0)

--- a/lacommunaute/notification/utils.py
+++ b/lacommunaute/notification/utils.py
@@ -28,7 +28,4 @@ def collect_first_replies():
 
 
 def collect_new_users_for_onboarding():
-    return [
-        (user.email, user.first_name, user.last_name)
-        for user in User.objects.filter(date_joined__gte=last_notification(kind=EmailSentTrackKind.ONBOARDING))
-    ]
+    return User.objects.filter(date_joined__gte=last_notification(kind=EmailSentTrackKind.ONBOARDING))


### PR DESCRIPTION
## Description

🎸 Remplacer l'envoi unitaire par un envoi groupé des nouveaux utilisateurs dans la séquence d'onboarding.
🎸 Correction des `attributes` pour valoriser les noms et prénoms

## Type de changement

🚧 technique / performance

### Points d'attention

🦺 complément de la PR #195 

