### PR TITLE
Ajouter l'auteur d'un sujet dans la liste des "likers" du sujet

### DIFF
--- a/lacommunaute/forum_conversation/tests/tests_views.py
+++ b/lacommunaute/forum_conversation/tests/tests_views.py
@@ -10,6 +10,7 @@ from machina.core.loading import get_class
 
 from lacommunaute.forum.factories import ForumFactory
 from lacommunaute.forum_conversation.factories import PostFactory, TopicFactory
+from lacommunaute.forum_conversation.models import Topic
 from lacommunaute.forum_conversation.views import PostDeleteView, TopicCreateView, TopicUpdateView
 from lacommunaute.forum_member.shortcuts import get_forum_member_display_name
 from lacommunaute.forum_upvote.factories import CertifiedPostFactory, UpVoteFactory
@@ -70,6 +71,19 @@ class TopicCreateViewTest(TestCase):
         )
         self.assertEqual(response.status_code, 200)
         self.assertEqual(1, TopicReadTrack.objects.count())
+
+    def test_topic_poster_is_added_to_likers_list(self):
+        assign_perm("can_start_new_topics", self.poster, self.forum)
+        self.client.force_login(self.poster)
+
+        post_data = {"subject": "s", "content": "c"}
+        response = self.client.post(
+            self.url,
+            post_data,
+            follow=True,
+        )
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(1, Topic.objects.first().likers.count())
 
 
 class TopicUpdateViewTest(TestCase):

--- a/lacommunaute/forum_conversation/views.py
+++ b/lacommunaute/forum_conversation/views.py
@@ -35,7 +35,11 @@ class FormValidMixin:
 
 
 class TopicCreateView(SuccessUrlMixin, FormValidMixin, views.TopicCreateView):
-    pass
+    # add poster to likers list when creating a topic
+    def form_valid(self, *args, **kwargs):
+        valid = super().form_valid(*args, **kwargs)
+        self.forum_post.topic.likers.add(self.request.user)
+        return valid
 
 
 class TopicUpdateView(SuccessUrlMixin, FormValidMixin, views.TopicUpdateView):


### PR DESCRIPTION
## Description

🎸 L'auteur d'un sujet est automatiquement ajouté à la liste des `likers` du `topic` pour envoyer des notifications sur l'activité de son sujet (ie reponses)

## Type de changement

🎢 Nouvelle fonctionnalité (changement non cassant qui ajoute une fonctionnalité).

