### PR TITLE
Gérer les landing pages sur le site

### DIFF
--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -33,6 +33,7 @@ DJANGO_APPS = [
     "django.contrib.postgres",
     "django.contrib.sites",
     "django.contrib.redirects",
+    "django.contrib.flatpages",
 ]
 
 THIRD_PARTIES_APPS = [

--- a/config/urls.py
+++ b/config/urls.py
@@ -1,7 +1,8 @@
 from django.conf import settings
 from django.conf.urls.static import static
 from django.contrib import admin
-from django.urls import include, path
+from django.contrib.flatpages import views
+from django.urls import include, path, re_path
 from machina.core.loading import get_class
 
 from lacommunaute.www.event_views import urls as event_urls
@@ -35,7 +36,13 @@ urlpatterns = [
     path("", include(conversation_urlpatterns_factory.urlpatterns)),
     path("moderation/", include(moderation_urlpatterns_factory.urlpatterns)),
     path("tracking/", include(tracking_urlpatterns_factory.urlpatterns)),
-] + static(settings.MEDIA_URL, document_root=settings.MEDIA_ROOT)
+]
+
+urlpatterns += static(settings.MEDIA_URL, document_root=settings.MEDIA_ROOT)
+
+urlpatterns += [
+    re_path(r"^(?P<url>.*/)$", views.flatpage),
+]
 
 if settings.DEBUG and "debug_toolbar" in settings.INSTALLED_APPS:
     import debug_toolbar

--- a/lacommunaute/templates/flatpages/default.html
+++ b/lacommunaute/templates/flatpages/default.html
@@ -1,0 +1,25 @@
+{% extends "layouts/base.html" %}
+
+{% block title %}{{ flatpage.title }}{{ block.super }}{% endblock %}
+{% block body_class %}{{ block.super }}{% endblock %}
+
+{% block breadcrumb %}
+    <section>
+        <div class="container">
+            <div class="row">
+                <div class="col-12">
+                    <nav class="c-breadcrumb c-breadcrumb--communaute" aria-label="Fil d'ariane">
+                        <ol class="breadcrumb">
+                            <li class="breadcrumb-item"><a href="{% url 'forum_extension:home' %}">Accueil</a></li>
+                            <li class="breadcrumb-item active" aria-current="page">{{ flatpage.title }}</li>
+                        </ol>
+                    </nav>
+                </div>
+            </div>
+        </div>
+    </section>
+{% endblock %}
+
+{% block content %}
+    {{ flatpage.content }}
+{% endblock %}

--- a/lacommunaute/templates/pages/landing_pages.html
+++ b/lacommunaute/templates/pages/landing_pages.html
@@ -1,0 +1,51 @@
+{% extends "layouts/base.html" %}
+{% load flatpages %}
+
+
+{% block title %}{{ flatpage.title }}{{ block.super }}{% endblock %}
+{% block body_class %}{{ block.super }}{% endblock %}
+
+{% block breadcrumb %}
+    <section>
+        <div class="container">
+            <div class="row">
+                <div class="col-12">
+                    <nav class="c-breadcrumb c-breadcrumb--communaute" aria-label="Fil d'ariane">
+                        <ol class="breadcrumb">
+                            <li class="breadcrumb-item"><a href="{% url 'forum_extension:home' %}">Accueil</a></li>
+                            <li class="breadcrumb-item active" aria-current="page">Liste des landing pages</li>
+                        </ol>
+                    </nav>
+                </div>
+            </div>
+        </div>
+    </section>
+{% endblock %}
+
+{% block content %}
+    {% get_flatpages as flatpages %}
+    <section class="s-title-01">
+        <div class="s-title-01__container container">
+            <div class="s-title-01__row row">
+                <div class="s-title-01__col col-12">
+                    <h1 class="s-title-01__title h1"><strong>Liste des landing pages actives sur le site</strong></h1>
+                </div>
+            </div>
+        </div>
+    </section>
+    <section class="s-cms">
+        <div class="s-cms__container container container-max-lg">
+            <div class="s-cms__row row">
+                <div class="s-cms__col col-12">
+                    <article>
+                        <ul>
+                            {% for page in flatpages %}
+                                <li><a href="{{ page.url }}">{{ page.title }}</a></li>
+                            {% endfor %}
+                        </ul>
+                    </article>
+                </div>
+            </div>
+        </div>
+    </section>
+{% endblock %}

--- a/lacommunaute/templates/partials/header_nav_primary_items.html
+++ b/lacommunaute/templates/partials/header_nav_primary_items.html
@@ -57,6 +57,9 @@
                             <a class="dropdown-item text-primary" href="{% url 'admin:auth_group_changelist' %}">Gérer les groupes</a>
                         </li>
                         <li>
+                            <a class="dropdown-item text-primary" href="{% url 'pages:landing_pages' %}">Liste des landing pages</a>
+                        </li>
+                        <li>
                             <a class="dropdown-item text-primary" href="{% url 'admin:index' %}">Accéder à l'admin</a>
                         </li>
                     {% endif %}

--- a/lacommunaute/www/pages/tests.py
+++ b/lacommunaute/www/pages/tests.py
@@ -5,6 +5,7 @@ from machina.core.loading import get_class
 
 from lacommunaute.forum_stats.enums import Period
 from lacommunaute.forum_stats.factories import StatFactory
+from lacommunaute.users.factories import UserFactory
 
 
 assign_perm = get_class("forum_permission.shortcuts", "assign_perm")
@@ -44,3 +45,23 @@ class StatistiquesPageTest(TestCase):
 
         # undesired values
         self.assertNotIn(other_period_stat.date.strftime("%Y-%m-%d"), response.context["stats"]["date"])
+
+
+class LandingPagesListViewTest(TestCase):
+    def test_context_data(self):
+        url = reverse("pages:landing_pages")
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, 302)
+
+        self.client.force_login(UserFactory())
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, 403)
+
+        self.client.force_login(UserFactory(is_staff=True))
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, 403)
+
+        self.client.force_login(UserFactory(is_superuser=True))
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, 200)
+        self.assertTemplateUsed(response, "pages/landing_pages.html")

--- a/lacommunaute/www/pages/urls.py
+++ b/lacommunaute/www/pages/urls.py
@@ -9,5 +9,6 @@ urlpatterns = [
     path("contact/", views.contact, name="contact"),
     path("statistiques/", views.StatistiquesPageView.as_view(), name="statistiques"),
     path("accessibilite/", views.accessibilite, name="accessibilite"),
+    path("landing-pages/", views.LandingPagesListView.as_view(), name="landing_pages"),
     path("sentry-debug/", views.trigger_error, name="sentry_debug"),
 ]

--- a/lacommunaute/www/pages/views.py
+++ b/lacommunaute/www/pages/views.py
@@ -1,5 +1,6 @@
 import logging
 
+from django.contrib.auth.mixins import UserPassesTestMixin
 from django.db.models import CharField
 from django.db.models.functions import Cast
 from django.shortcuts import render
@@ -32,6 +33,13 @@ class StatistiquesPageView(TemplateView):
         context["stats"] = extract_values_in_list(datas, indicator_names)
 
         return context
+
+
+class LandingPagesListView(UserPassesTestMixin, TemplateView):
+    template_name = "pages/landing_pages.html"
+
+    def test_func(self):
+        return self.request.user.is_superuser
 
 
 def accessibilite(request):


### PR DESCRIPTION
## Description

🎸 Permettre la création de landing pages depuis l'admin, sans redéploiement de code
🎸 Permettre aux utilisateurs `superuser` de visualiser la liste des landing pages existantes depuis leur `navbar`

## Type de changement

🎢 Nouvelle fonctionnalité (changement non cassant qui ajoute une fonctionnalité).

### Points d'attention

🦺 Par défault, les landing utilisent le gabarit standard du site
🦺 Exploitation de l'app `flatpages` de Django
🦺 Les urls des `flatpages` ne sont pas prioritaires, elles sont déclarées en fin de liste des urls


### Captures d'écran (optionnel)

Ecran d'admin de mise à jour d'une `flatpage`
![image](https://user-images.githubusercontent.com/11419273/227161559-dc55b161-59a3-4cf6-b8b0-88c695bd97f4.png)

Vue de la `flatpage` correspondante
![image](https://user-images.githubusercontent.com/11419273/227161800-11f14dbc-b628-43a3-bbe6-41302a25053d.png)

Lien vers la liste des `flatpages` dans la `navbar`
![image](https://user-images.githubusercontent.com/11419273/227162098-792eaf65-5142-4432-a553-124b27ef351d.png)

Page de liste des `flatpages` actives sur le site
![image](https://user-images.githubusercontent.com/11419273/227162230-6aa33342-1390-4501-a98a-3aef709bcc01.png)
