### PR TITLE
FIX : Ne pas ajouter un poster non authentifié à la liste des likers d'un Sujet

### DIFF
--- a/lacommunaute/forum_conversation/views.py
+++ b/lacommunaute/forum_conversation/views.py
@@ -38,7 +38,8 @@ class TopicCreateView(SuccessUrlMixin, FormValidMixin, views.TopicCreateView):
     # add poster to likers list when creating a topic
     def form_valid(self, *args, **kwargs):
         valid = super().form_valid(*args, **kwargs)
-        self.forum_post.topic.likers.add(self.request.user)
+        if self.request.user.is_authenticated:
+            self.forum_post.topic.likers.add(self.request.user)
         return valid
 
 

--- a/lacommunaute/forum_conversation/views.py
+++ b/lacommunaute/forum_conversation/views.py
@@ -35,7 +35,6 @@ class FormValidMixin:
 
 
 class TopicCreateView(SuccessUrlMixin, FormValidMixin, views.TopicCreateView):
-    # add poster to likers list when creating a topic
     def form_valid(self, *args, **kwargs):
         valid = super().form_valid(*args, **kwargs)
         if self.request.user.is_authenticated:


### PR DESCRIPTION
## Description

🎸 Ne pas ajouter l'utilisateur non authentifié qui poste un nouveau sujet, à la liste des likers de ce sujet

## Type de changement

🪲 Correction de bug | PR #200 

