### PR TITLE
Mise à jour de l'affichage du nom de l'auteur d'un post

### DIFF
--- a/lacommunaute/templates/forum_conversation/partials/poster.html
+++ b/lacommunaute/templates/forum_conversation/partials/poster.html
@@ -9,19 +9,19 @@
         <i class="fas fa-clock"></i>&nbsp;
         {% if post.poster %}
             {% url 'members:profile' post.poster_id as poster_url %}
-            {% blocktrans trimmed with poster_url=poster_url username=post.poster|forum_member_display_name creation_date=post.created %}
+            {% blocktrans trimmed with poster_url=poster_url poster=post.poster_display_name creation_date=post.created %}
                 By:
                 <a href="{{ poster_url }}"
                     class="matomo-event"
                     data-matomo-category="engagement"
                     data-matomo-action="view"
                     data-matomo-option="member">
-                    {{ username }}
+                    {{ poster }}
                 </a>,
             {% endblocktrans %}
         {% else %}
-            {% blocktrans trimmed with poster_username="Utilisateur anonyme" creation_date=post.created %}
-                By: {{ poster_username }},
+            {% blocktrans trimmed with poster=post.poster_display_name creation_date=post.created %}
+                By: {{ poster }},
             {% endblocktrans %}
         {% endif %}
     {% endspaceless %}

--- a/lacommunaute/www/forum_conversation_views/tests.py
+++ b/lacommunaute/www/forum_conversation_views/tests.py
@@ -200,9 +200,20 @@ class PostListViewTest(TestCase):
         self.assertNotContains(response, self.topic.first_post.content)  # original post content excluded
         self.assertContains(response, posts[0].content)
         self.assertContains(response, posts[1].content)
+        self.assertContains(response, posts[0].poster_display_name)
         self.assertIsInstance(response.context["form"], PostForm)
         self.assertEqual(1, ForumReadTrack.objects.count())
         self.assertEqual(response.context["next_url"], self.topic.get_absolute_url())
+
+    def test_get_list_of_posts_posted_by_anonymous_user(self):
+        username = faker.email()
+        post = PostFactory(topic=self.topic, poster=None, username=username)
+        self.client.force_login(self.user)
+
+        response = self.client.get(self.url)
+
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(response, post.poster_display_name)
 
     def test_get_list_of_posts_linked_to_annonce_topic(self):
         post = PostFactory(topic=self.topic, poster=self.user)


### PR DESCRIPTION
## Description

🎸 Harmoniser l'affichage avec les notifications emails

- Si le sujet ou la réponse est postée par un utilisateur authentifié : afficher son prénom + la premiere lettre de son nom (inchangé)
- Si le sujet ou la réponse est postée par un utilisateur NON authentifié : afficher le radical de son adresse email (la partie avant @) 

## Type de changement

🎢 Nouvelle fonctionnalité (changement non cassant qui ajoute une fonctionnalité).

