### PR TITLE
FIX - suppression du warning lors de la recupération des stats d'un forum

### DIFF
--- a/lacommunaute/forum/models.py
+++ b/lacommunaute/forum/models.py
@@ -1,6 +1,5 @@
 import uuid
 
-from dateutil.relativedelta import relativedelta
 from django.contrib.auth.models import Group
 from django.db import models
 from django.db.models.functions import TruncWeek
@@ -26,7 +25,7 @@ class Forum(AbstractForum):
 
     def get_stats(self, period_back):
 
-        start_date = timezone.localdate() - relativedelta(days=period_back * DAYS_IN_A_PERIOD - 1)
+        start_date = timezone.now() - timezone.timedelta(days=period_back * DAYS_IN_A_PERIOD - 1)
         forums = self.get_family()
 
         datas = (

--- a/lacommunaute/forum/tests.py
+++ b/lacommunaute/forum/tests.py
@@ -1,4 +1,3 @@
-from dateutil.relativedelta import relativedelta
 from django.db import IntegrityError
 from django.test import TestCase
 from django.utils import timezone
@@ -37,7 +36,7 @@ class ForumModelTest(TestCase):
         UpVoteFactory(post=topic.posts.first(), voter=topic.poster)
 
         # create old instance to ensure they are filtered
-        fifteen_days_ago = timezone.now() - relativedelta(days=15)
+        fifteen_days_ago = timezone.now() - timezone.timedelta(days=15)
         old_topic = TopicFactory(forum=forum)
         old_topic.created = fifteen_days_ago
         old_topic.save()


### PR DESCRIPTION
## Description

🎸 Utilisation d'une date avec timezone dans la méthode `forum.get_stats()` pour supprimer le warning.

## Type de changement

🚧 technique

## trace logs 

```
lacommunaute/forum/tests.py::ForumModelTest::test_get_stats
  /home/vincentporte/Neuralia.co.Products/betagouv/itou-communaute-django/.venv/lib/python3.10/site-packages/django/db/models/fields/__init__.py:1504: RuntimeWarning: DateTimeField Topic.created received a naive datetime (2023-03-09 00:00:00) while time zone support is active.
    warnings.warn(

lacommunaute/forum/tests.py::ForumModelTest::test_get_stats
  /home/vincentporte/Neuralia.co.Products/betagouv/itou-communaute-django/.venv/lib/python3.10/site-packages/django/db/models/fields/__init__.py:1504: RuntimeWarning: DateTimeField Post.created received a naive datetime (2023-03-09 00:00:00) while time zone support is active.
    warnings.warn(

lacommunaute/forum/tests.py::ForumModelTest::test_get_stats
  /home/vincentporte/Neuralia.co.Products/betagouv/itou-communaute-django/.venv/lib/python3.10/site-packages/django/db/models/fields/__init__.py:1504: RuntimeWarning: DateTimeField UpVote.created_at received a naive datetime (2023-03-09 00:00:00) while time zone support is active.
    warnings.warn(

lacommunaute/forum/tests.py::ForumModelTest::test_get_stats
  /home/vincentporte/Neuralia.co.Products/betagouv/itou-communaute-django/.venv/lib/python3.10/site-packages/django/db/models/fields/__init__.py:1504: RuntimeWarning: DateTimeField TopicPollVote.timestamp received a naive datetime (2023-03-09 00:00:00) while time zone support is active.
    warnings.warn(```
