### PR TITLE
Ajout du lien "voir plus" sur les réponses certifiées

### DIFF
--- a/lacommunaute/forum_conversation/tests/tests_views.py
+++ b/lacommunaute/forum_conversation/tests/tests_views.py
@@ -13,7 +13,6 @@ from lacommunaute.forum.factories import ForumFactory
 from lacommunaute.forum_conversation.factories import PostFactory, TopicFactory
 from lacommunaute.forum_conversation.models import Topic
 from lacommunaute.forum_conversation.views import PostDeleteView, TopicCreateView, TopicUpdateView
-from lacommunaute.forum_member.shortcuts import get_forum_member_display_name
 from lacommunaute.forum_upvote.factories import CertifiedPostFactory, UpVoteFactory
 from lacommunaute.users.factories import UserFactory
 
@@ -397,12 +396,12 @@ class TopicViewTest(TestCase):
 
         response = self.client.get(self.url)
         self.assertEqual(response.status_code, 200)
-        self.assertNotContains(response, "Certifié par")
+        self.assertNotContains(response, "Certifié par la Plateforme de l'Inclusion")
 
         CertifiedPostFactory(topic=self.topic, post=post, user=self.poster)
         response = self.client.get(self.url)
         self.assertEqual(response.status_code, 200)
-        self.assertContains(response, f"Certifié par {get_forum_member_display_name(self.topic.certified_post.user)}")
+        self.assertContains(response, "Certifié par la Plateforme de l'Inclusion")
 
     def test_numqueries(self):
         PostFactory.create_batch(10, topic=self.topic, poster=self.poster)
@@ -411,6 +410,6 @@ class TopicViewTest(TestCase):
         self.client.force_login(self.poster)
 
         # note vincentporte : to be optimized
-        with self.assertNumQueries(44):
+        with self.assertNumQueries(43):
             response = self.client.get(self.url)
         self.assertEqual(response.status_code, 200)

--- a/lacommunaute/templates/forum_conversation/partials/post_certified.html
+++ b/lacommunaute/templates/forum_conversation/partials/post_certified.html
@@ -18,8 +18,21 @@
                             {%include "forum_conversation/partials/post_certified_badge.html"%}
                         </div>
                     </div>
-                    <div class="post-content">
-                        {{ post.content.rendered|urlizetrunc_target_blank:30}}
+                    <div class="post-content" id="showmorecertifiedpostsarea{{topic.pk}}">
+                        {{ post.content.rendered|urlizetrunc_target_blank:30|truncatechars:200 }}
+                        {% if post.content.rendered|length > 200 %}
+                            <a hx-get="{% url 'forum_conversation_extension:showmore_certified' topic.forum.slug topic.forum.pk topic.slug topic.pk %}"
+                                id="showmorecertified-button{{topic.pk}}"
+                                hx-target="#showmorecertifiedpostsarea{{topic.pk}}"
+                                hx-swap="outerHTML"
+                                class="btn btn-link p-0 mh-auto matomo-event"
+                                data-matomo-category="engagement"
+                                data-matomo-action="showmore"
+                                data-matomo-option="certified"
+                            >
+                                {% trans "+ show more" %}
+                            </a>
+                        {% endif %}
                         {% include "forum_conversation/forum_attachments/attachments_images.html" %}
                     </div>
                     {% include "forum_conversation/forum_attachments/attachments_detail.html" with post=post user_can_download_files=user_can_download_files %}

--- a/lacommunaute/templates/forum_conversation/partials/post_certified_badge.html
+++ b/lacommunaute/templates/forum_conversation/partials/post_certified_badge.html
@@ -1,14 +1,9 @@
 {% load forum_member_tags %}
 
 {% if post.is_certified %}
-    <a href="{% url 'members:profile' post.certified_post.user.id %}"
-        class="matomo-event badge badge-xs badge-pill bg-communaute text-white text-decoration-none"
-        data-matomo-category="engagement"
-        data-matomo-action="view"
-        data-matomo-option="member">
-        <i class="ri-award-line" aria-hidden="true"></i>
-        Certifié par {{post.certified_post.user|forum_member_display_name}}
-    </a>
+    <span class="badge badge-xs badge-pill bg-communaute text-white text-decoration-none">
+        Certifié par la Plateforme de l'Inclusion
+    </span>
 {% endif %}
 
 

--- a/lacommunaute/templates/forum_conversation/partials/topic_certified_post.html
+++ b/lacommunaute/templates/forum_conversation/partials/topic_certified_post.html
@@ -1,0 +1,3 @@
+{% load str_filters %}
+
+{{ topic.certified_post.post.content.rendered|urlizetrunc_target_blank:30 }}

--- a/lacommunaute/www/forum_conversation_views/tests.py
+++ b/lacommunaute/www/forum_conversation_views/tests.py
@@ -7,7 +7,6 @@ from machina.core.loading import get_class
 from lacommunaute.forum_conversation.factories import PostFactory, TopicFactory
 from lacommunaute.forum_conversation.forms import PostForm
 from lacommunaute.forum_conversation.models import Topic
-from lacommunaute.forum_member.shortcuts import get_forum_member_display_name
 from lacommunaute.forum_upvote.factories import CertifiedPostFactory, UpVoteFactory
 from lacommunaute.users.factories import UserFactory
 from lacommunaute.www.forum_conversation_views.views import PostListView
@@ -284,12 +283,12 @@ class PostListViewTest(TestCase):
 
         response = self.client.get(self.url)
         self.assertEqual(response.status_code, 200)
-        self.assertNotContains(response, "Certifié par")
+        self.assertNotContains(response, "Certifié par la Plateforme de l'Inclusion")
 
         CertifiedPostFactory(topic=self.topic, post=post, user=self.user)
         response = self.client.get(self.url)
         self.assertEqual(response.status_code, 200)
-        self.assertContains(response, f"Certifié par {get_forum_member_display_name(self.topic.certified_post.user)}")
+        self.assertContains(response, "Certifié par la Plateforme de l'Inclusion")
 
 
 class PostFeedCreateViewTest(TestCase):

--- a/lacommunaute/www/forum_conversation_views/tests.py
+++ b/lacommunaute/www/forum_conversation_views/tests.py
@@ -105,7 +105,7 @@ class TopicLikeViewTest(TestCase):
         self.assertEqual(1, TopicReadTrack.objects.count())
 
 
-class TopicContentView(TestCase):
+class TopicContentViewTest(TestCase):
     @classmethod
     def setUpTestData(cls):
         cls.topic = TopicFactory()

--- a/lacommunaute/www/forum_conversation_views/tests.py
+++ b/lacommunaute/www/forum_conversation_views/tests.py
@@ -153,6 +153,29 @@ class TopicContentViewTest(TestCase):
         self.assertEqual(1, ForumReadTrack.objects.count())
 
 
+class TopicCertifiedPostViewTest(TestCase):
+    def test_get_topic_certified_post(self):
+        topic = TopicFactory(with_certified_post=True)
+        user = topic.poster
+        assign_perm("can_read_forum", user, topic.forum)
+        url = reverse(
+            "forum_conversation_extension:showmore_certified",
+            kwargs={
+                "forum_pk": topic.forum.pk,
+                "forum_slug": topic.forum.slug,
+                "pk": topic.pk,
+                "slug": topic.slug,
+            },
+        )
+        self.client.force_login(user)
+
+        response = self.client.get(url)
+
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(response, topic.certified_post.post.content)
+        self.assertEqual(1, ForumReadTrack.objects.count())
+
+
 class PostListViewTest(TestCase):
     @classmethod
     def setUpTestData(cls):

--- a/lacommunaute/www/forum_conversation_views/urls.py
+++ b/lacommunaute/www/forum_conversation_views/urls.py
@@ -3,6 +3,7 @@ from django.urls import include, path
 from lacommunaute.www.forum_conversation_views.views import (
     PostFeedCreateView,
     PostListView,
+    TopicCertifiedPostView,
     TopicContentView,
     TopicLikeView,
 )
@@ -14,6 +15,7 @@ conversation_urlpatterns = [
     path("topic/<str:slug>-<int:pk>/like", TopicLikeView.as_view(), name="like_topic"),
     path("topic/<str:slug>-<int:pk>/showmore/topic", TopicContentView.as_view(), name="showmore_topic"),
     path("topic/<str:slug>-<int:pk>/showmore/posts", PostListView.as_view(), name="showmore_posts"),
+    path("topic/<str:slug>-<int:pk>/showmore/certified", TopicCertifiedPostView.as_view(), name="showmore_certified"),
     path("topic/<str:slug>-<int:pk>/comment", PostFeedCreateView.as_view(), name="post_create"),
 ]
 

--- a/lacommunaute/www/forum_conversation_views/views.py
+++ b/lacommunaute/www/forum_conversation_views/views.py
@@ -81,6 +81,10 @@ class TopicContentView(PermissionRequiredMixin, View):
         return self.get_topic().forum
 
 
+class TopicCertifiedPostView(TopicContentView):
+    template = "forum_conversation/partials/topic_certified_post.html"
+
+
 class PostListView(PermissionRequiredMixin, View):
     permission_required = [
         "can_read_forum",

--- a/lacommunaute/www/forum_conversation_views/views.py
+++ b/lacommunaute/www/forum_conversation_views/views.py
@@ -53,6 +53,7 @@ class TopicLikeView(PermissionRequiredMixin, View):
 
 
 class TopicContentView(PermissionRequiredMixin, View):
+    template = "forum_conversation/partials/topic_content.html"
     permission_required = [
         "can_read_forum",
     ]
@@ -72,7 +73,7 @@ class TopicContentView(PermissionRequiredMixin, View):
 
         return render(
             request,
-            "forum_conversation/partials/topic_content.html",
+            self.template,
             context={"topic": topic},
         )
 

--- a/lacommunaute/www/forum_views/tests_views.py
+++ b/lacommunaute/www/forum_views/tests_views.py
@@ -14,7 +14,6 @@ from lacommunaute.forum_conversation.forms import PostForm
 from lacommunaute.forum_conversation.forum_attachments.factories import AttachmentFactory
 from lacommunaute.forum_conversation.forum_polls.factories import TopicPollFactory, TopicPollVoteFactory
 from lacommunaute.forum_conversation.models import Topic
-from lacommunaute.forum_member.shortcuts import get_forum_member_display_name
 from lacommunaute.users.factories import UserFactory
 from lacommunaute.www.forum_views.views import ForumView
 
@@ -305,7 +304,7 @@ class ForumViewTest(TestCase):
 
         self.assertEqual(response.status_code, 200)
         self.assertContains(response, topic.last_post.content)
-        self.assertContains(response, f"Certifié par {get_forum_member_display_name(topic.certified_post.user)}")
+        self.assertContains(response, "Certifié par la Plateforme de l'Inclusion")
         self.assertEqual(topic.posts.count(), 2)
 
 

--- a/lacommunaute/www/forum_views/tests_views.py
+++ b/lacommunaute/www/forum_views/tests_views.py
@@ -14,6 +14,7 @@ from lacommunaute.forum_conversation.forms import PostForm
 from lacommunaute.forum_conversation.forum_attachments.factories import AttachmentFactory
 from lacommunaute.forum_conversation.forum_polls.factories import TopicPollFactory, TopicPollVoteFactory
 from lacommunaute.forum_conversation.models import Topic
+from lacommunaute.forum_upvote.factories import CertifiedPostFactory
 from lacommunaute.users.factories import UserFactory
 from lacommunaute.www.forum_views.views import ForumView
 
@@ -294,18 +295,16 @@ class ForumViewTest(TestCase):
         response = self.client.get(self.url)
 
         self.assertEqual(response.status_code, 200)
-        self.assertNotContains(response, post.content)
-        self.assertEqual(self.topic.posts.count(), 2)
+        self.assertNotContains(response, post.content.rendered)
 
-        # create a certified post
-        topic = TopicFactory(with_certified_post=True, forum=self.forum)
+        # certify post
+        CertifiedPostFactory(topic=self.topic, post=post, user=self.user)
 
         response = self.client.get(self.url)
 
         self.assertEqual(response.status_code, 200)
-        self.assertContains(response, topic.last_post.content)
+        self.assertContains(response, post.content.rendered)
         self.assertContains(response, "Certifié par la Plateforme de l'Inclusion")
-        self.assertEqual(topic.posts.count(), 2)
 
 
 class ModeratorEngagementViewTest(TestCase):


### PR DESCRIPTION
## Description

🎸 Afficher les 200 premiers caractères d'une réponse certifiée
🎸 Ajouter le lien "voir plus" pour déplier la réponse
🎸 Ajout de la vue HTMX `TopicCertifiedPostView` pour afficher le contenu de `topic.certified_post.post.content`

## Type de changement

🎢 Nouvelle fonctionnalité (changement non cassant qui ajoute une fonctionnalité).

### Points d'attention

🦺 Vue HTMX

### Captures d'écran (optionnel)

Fil d'actualités au chargement de la page
![image](https://user-images.githubusercontent.com/11419273/227908307-11a6aa5f-dd7c-4aea-963a-505a837a216c.png)

Réponse certifiée dépliée
![image](https://user-images.githubusercontent.com/11419273/227908561-2f93e734-da5a-4370-b1b2-d8968a610b0c.png)

Topic déplié (independant de la réponse certifiée)
![image](https://user-images.githubusercontent.com/11419273/227908730-48b3bd35-acf7-49b7-b4a9-b9ae8abee840.png)

