### PR TITLE
Afficher les questions en attentes de réponse

### DIFF
--- a/lacommunaute/forum/tests.py
+++ b/lacommunaute/forum/tests.py
@@ -6,9 +6,9 @@ from machina.core.db.models import get_model
 from machina.core.loading import get_class
 
 from lacommunaute.forum.factories import ForumFactory
+from lacommunaute.forum.models import Forum
 from lacommunaute.forum_conversation.factories import PostFactory, TopicFactory
 from lacommunaute.forum_conversation.forum_polls.factories import TopicPollVoteFactory
-from lacommunaute.forum_conversation.models import Topic
 from lacommunaute.forum_upvote.factories import UpVoteFactory
 
 
@@ -19,6 +19,17 @@ UserForumPermission = get_model("forum_permission", "UserForumPermission")
 PermissionHandler = get_class("forum_permission.handler", "PermissionHandler")
 assign_perm = get_class("forum_permission.shortcuts", "assign_perm")
 remove_perm = get_class("forum_permission.shortcuts", "remove_perm")
+
+
+class ForumManagerTest(TestCase):
+    def test_private_forum(self):
+        ForumFactory(is_private=True)
+        self.assertEqual(Forum.objects.public().count(), 0)
+
+    def test_public_forum(self):
+        forum = ForumFactory(is_private=False)
+        self.assertEqual(Forum.objects.public().count(), 1)
+        self.assertIn(forum, Forum.objects.public())
 
 
 class ForumModelTest(TestCase):
@@ -66,18 +77,17 @@ class ForumModelTest(TestCase):
             },
         )
 
+    def test_get_unanswered_topics(self):
+        topic1 = TopicFactory(forum=ForumFactory(), posts_count=1)
+        topic2 = TopicFactory(forum=ForumFactory(parent=topic1.forum), posts_count=1)
+        TopicFactory(forum=ForumFactory(), posts_count=1)
+
+        unanswered_topics = topic1.forum.get_unanswered_topics()
+        self.assertEqual(unanswered_topics.count(), 2)
+        self.assertIn(topic1, unanswered_topics)
+        self.assertIn(topic2, unanswered_topics)
+
     def test_count_unanswered_topics(self):
-        forum = ForumFactory()
-
-        TopicFactory(forum=forum, posts_count=0)
-        TopicFactory(forum=forum, posts_count=1)
-        TopicFactory(forum=forum, posts_count=2)
-
-        TopicFactory(forum=forum, posts_count=1, status=Topic.TOPIC_LOCKED)
-        TopicFactory(forum=forum, posts_count=1, type=Topic.TOPIC_ANNOUNCE)
-        TopicFactory(forum=forum, posts_count=1, approved=False)
-
-        subforum = ForumFactory(parent=forum)
-        TopicFactory(forum=subforum, posts_count=1)
-
-        self.assertEqual(forum.count_unanswered_topics, 2)
+        topic = TopicFactory(forum=ForumFactory(), posts_count=1)
+        TopicFactory(forum=ForumFactory(parent=topic.forum), posts_count=1)
+        self.assertEqual(topic.forum.count_unanswered_topics, 2)

--- a/lacommunaute/forum_conversation/models.py
+++ b/lacommunaute/forum_conversation/models.py
@@ -6,6 +6,15 @@ from machina.apps.forum_conversation.abstract_models import AbstractPost, Abstra
 from lacommunaute.forum_member.shortcuts import get_forum_member_display_name
 
 
+class TopicQuerySet(models.QuerySet):
+    def unanswered(self):
+        return (
+            self.exclude(approved=False)
+            .exclude(status=Topic.TOPIC_LOCKED)
+            .filter(posts_count=1, type__in=[Topic.TOPIC_POST, Topic.TOPIC_STICKY])
+        )
+
+
 class Topic(AbstractTopic):
     likers = models.ManyToManyField(
         settings.AUTH_USER_MODEL,
@@ -32,6 +41,8 @@ class Topic(AbstractTopic):
     @property
     def is_certified(self):
         return hasattr(self, "certified_post")
+
+    objects = TopicQuerySet().as_manager()
 
 
 class Post(AbstractPost):

--- a/lacommunaute/forum_conversation/tests/tests_models.py
+++ b/lacommunaute/forum_conversation/tests/tests_models.py
@@ -2,8 +2,9 @@ from django.core.exceptions import ValidationError
 from django.test import TestCase
 from django.urls import reverse
 
+from lacommunaute.forum.factories import ForumFactory
 from lacommunaute.forum_conversation.factories import PostFactory, TopicFactory
-from lacommunaute.forum_conversation.models import Post
+from lacommunaute.forum_conversation.models import Post, Topic
 from lacommunaute.forum_member.shortcuts import get_forum_member_display_name
 
 
@@ -21,6 +22,22 @@ class PostModelTest(TestCase):
 
         topic = TopicFactory(with_certified_post=True)
         self.assertTrue(topic.last_post.is_certified)
+
+
+class TopicManagerTest(TestCase):
+    def test(self):
+        forum = ForumFactory()
+
+        TopicFactory(forum=forum, posts_count=0)
+        topic = TopicFactory(forum=forum, posts_count=1)
+        TopicFactory(forum=forum, posts_count=2)
+
+        TopicFactory(forum=forum, posts_count=1, status=Topic.TOPIC_LOCKED)
+        TopicFactory(forum=forum, posts_count=1, type=Topic.TOPIC_ANNOUNCE)
+        TopicFactory(forum=forum, posts_count=1, approved=False)
+
+        self.assertEqual(Topic.objects.unanswered().count(), 1)
+        self.assertIn(topic, Topic.objects.unanswered())
 
 
 class TopicModelTest(TestCase):

--- a/lacommunaute/templates/forum_conversation/partials/post_certified.html
+++ b/lacommunaute/templates/forum_conversation/partials/post_certified.html
@@ -12,7 +12,7 @@
                 <div class="col-12 post-content-wrapper">
                     <div class="mb-1 d-flex flex-column flex-md-row">
                         <div class="mb-1 flex-grow-1">
-                            {%include "forum_conversation/partials/poster.html" with post=post topic=topic forum=topic.forum%}
+                            {%include "forum_conversation/partials/poster.html" with post=post topic=topic %}
                         </div>
                         <div>
                             {%include "forum_conversation/partials/post_certified_badge.html"%}

--- a/lacommunaute/templates/forum_conversation/partials/post_feed.html
+++ b/lacommunaute/templates/forum_conversation/partials/post_feed.html
@@ -12,7 +12,7 @@
             <div class="col-12 post-content-wrapper">
                 <div class="d-flex align-items-center mb-1">
                     <span class="mb-0 flex-grow-1">
-                        {%include "forum_conversation/partials/poster.html" with post=post topic=topic forum=topic.forum%}
+                        {%include "forum_conversation/partials/poster.html" with post=post topic=topic %}
                     </span>
                     {% include "forum_conversation/partials/post_upvotes.html"%}
                 </div>

--- a/lacommunaute/templates/forum_conversation/partials/poster.html
+++ b/lacommunaute/templates/forum_conversation/partials/poster.html
@@ -27,6 +27,6 @@
     {% endspaceless %}
     {{post.created|relativetimesince_fr}}
     {% if user_can_edit_post %}
-        - <a href="{% if is_topic_head %}{% url 'forum_conversation:topic_update' forum.slug forum.pk topic.slug topic.pk %}{% else %}{% url 'forum_conversation:post_update' forum.slug forum.pk topic.slug topic.pk post.pk %}{% endif %}" aria-label="{% trans "Edit" %}">{% trans "Edit" %}</a>
+        - <a href="{% if is_topic_head %}{% url 'forum_conversation:topic_update' topic.forum.slug topic.forum.pk topic.slug topic.pk %}{% else %}{% url 'forum_conversation:post_update' topic.forum.slug topic.forum.pk topic.slug topic.pk post.pk %}{% endif %}" aria-label="{% trans "Edit" %}">{% trans "Edit" %}</a>
     {% endif %}
 </small>

--- a/lacommunaute/templates/forum_conversation/partials/posts_list.html
+++ b/lacommunaute/templates/forum_conversation/partials/posts_list.html
@@ -15,7 +15,7 @@
                     <div class="col-12 post-content-wrapper">
                         <div class="mb-1 d-flex flex-column flex-md-row align-items-md-center">
                             <div class="mb-1 flex-grow-1">
-                                {% include "forum_conversation/partials/poster.html" with post=post topic=post.topic forum=post.topic.forum %}
+                                {% include "forum_conversation/partials/poster.html" with post=post topic=post.topic %}
                                 {% include "forum_conversation/partials/post_certified_actions.html" %}
                             </div>
                             <div>

--- a/lacommunaute/templates/forum_conversation/topic_detail.html
+++ b/lacommunaute/templates/forum_conversation/topic_detail.html
@@ -23,7 +23,7 @@
                     <div class="card-header mb-1 d-flex flex-column flex-md-row align-items-md-center">
                         <p class="h4 mb-0 flex-grow-1">
                             {% if topic.is_locked %}&nbsp;<i class="fas fa-times-circle locked-indicator" aria-label="{% trans 'This topic is locked' %}"></i>{% endif %}
-                            {% include "forum_conversation/partials/poster.html" with post=post topic=topic forum=topic.forum is_topic_head=True %}
+                            {% include "forum_conversation/partials/poster.html" with post=post topic=topic is_topic_head=True %}
                         </p>
                         {% block htmx %}
                             {% include "forum_conversation/partials/topic_likes.html" %}

--- a/lacommunaute/templates/forum_conversation/topic_list.html
+++ b/lacommunaute/templates/forum_conversation/topic_list.html
@@ -51,7 +51,7 @@
                                     <div class="card-body pt-0">
                                         <div class="row">
                                             <div class="col-12 post-content-wrapper mb-3">
-                                                {%include "forum_conversation/partials/poster.html" with post=topic.first_post topic=topic forum=forum is_topic_head=True%}
+                                                {%include "forum_conversation/partials/poster.html" with post=topic.first_post topic=topic is_topic_head=True%}
                                             </div>
                                             <div class="col-12 post-content">
                                                 <div id="showmoretopicsarea{{topic.pk}}">

--- a/lacommunaute/templates/forum_conversation/topic_list.html
+++ b/lacommunaute/templates/forum_conversation/topic_list.html
@@ -5,7 +5,9 @@
 {% load forum_tracking_tags %}
 {% load forum_permission_tags %}
 
-{% get_permission 'can_download_files' forum request.user as user_can_download_files %}
+{% if forum %}
+    {% get_permission 'can_download_files' forum request.user as user_can_download_files %}
+{% endif %}
 
 {% if topics or not hide_if_empty %}
     <div class="row mb-3">
@@ -72,6 +74,9 @@
                                                 </div>
                                                 {% include "forum_conversation/forum_attachments/attachments_images.html" with post=topic.first_post %}
 
+                                                {% if not forum %}
+                                                    {% get_permission 'can_download_files' topic.forum request.user as user_can_download_files %}
+                                                {% endif %}
                                                 {% include "forum_conversation/forum_attachments/attachments_detail.html" with post=topic.first_post user_can_download_files=user_can_download_files %}
 
                                                 {% if topic.poll %}

--- a/lacommunaute/templates/pages/home.html
+++ b/lacommunaute/templates/pages/home.html
@@ -23,22 +23,6 @@
             </div>
         </section>
 
-        <section class="s-section">
-            <div class="s-section__container container">
-                <div class="s-section__row row mb-1 mb-md-3">
-                    <div class="s-section__col col-12">
-                        {% forum_list forums %}
-                    </div>
-                </div>
-                <div class="s-section__row row mb-1 mb-md-3">
-                    <div class="s-section__col col-6">
-                        <a href="{% url 'event:calendar' %}" class="btn btn-primary btn-block">
-                            Accéder aux évènements publics
-                        </a>
-                    </div>
-                </div>
-            </div>
-        </section>
     {% else %}
         <section class="s-page-menu-01 s-page-menu-01--communaute">
             <div class="s-page-menu-01__container container">
@@ -100,17 +84,13 @@
         <section class="s-section">
             <div class="s-section__container container">
                 <div class="s-section__row row mb-1 mb-md-3">
-                    <div class="s-section__col col-12 anchor" id="community">
+                    <div class="s-section__col col-12">
                         <p>Nous déployons des communautés publiques et privées.</p>
                         <p>Ces communautés sont co-construites avec et pour les acteurs de l’inclusion en fonction de leurs besoins et de leurs objectifs. <br> Cliquez sur une communauté ci-dessous pour consulter les sujets en cours. Pour contribuer, connectez-vous avec Inclusion Connect.</p>
                     </div>
                 </div>
                 <div class="s-section__row row mb-1 mb-md-3">
-                    <div class="s-section__col col-12">
-                        <h2>Les communautés publiques</h2>
-                        {% forum_list forums %}
-                    </div>
-                    <div class="s-section__col col-12 mt-3">
+                    <div class="s-section__col col-12 mt-3 anchor" id="community">
                         <a href="{% url 'inclusion_connect:authorize' %}" class="btn btn-ico btn-outline-primary">
                             <i class="ri-login-box-line ri-lg"></i>
                             <span>
@@ -122,6 +102,68 @@
             </div>
         </section>
     {% endif %}
+
+    <section class="s-tabs-01">
+        <div class="s-tabs-01__container container">
+            <div class="s-tabs-01__row row">
+                <div class="s-tabs-01__col col-12">
+                    <ul class="s-tabs-01__nav nav nav-tabs" role="tablist">
+                        <li class="nav-item" role="presentation">
+                            <a class="nav-link{% if forums_tab %} active{% endif %}" id="forums_tab"
+                                data-toggle="tab"
+                                href="#forums"
+                                role="tab"
+                                aria-controls="forums"
+                                aria-selected="{% if forums_tab %}true{% else %}false{% endif %}">
+                                Thématiques
+                            </a>
+                        </li>
+                        <li class="nav-item" role="presentation">
+                            <a class="nav-link{% if pending_topics_tab %} active{% endif %}" id="pending-topics-tab"
+                                data-toggle="tab"
+                                href="#pending-topics"
+                                role="tab"
+                                aria-controls="pending-topics"
+                                aria-selected="{% if pending_topics_tab %}true{% else %}false{% endif %}">
+                                Questions en attente
+                            </a>
+                        </li>
+                    </ul>
+                    <div class="tab-content">
+                        <div class="tab-pane fade{% if forums_tab %} show active{% endif %}" id="forums"
+                            role="tabpanel"
+                            aria-labelledby="forums_tab">
+                            {% forum_list forums %}
+                        </div>
+                        <div class="tab-pane fade{% if pending_topics_tab %} show active{% endif %}" id="pending-topics"
+                            role="tabpanel"
+                            aria-labelledby="pending-topics-tab">
+                            {% with topics=topics topic_list_title="Questions en attente" %}
+                                {% include "forum_conversation/topic_list.html" %}
+                            {% endwith %}
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </section>
+
+
+    {% if user.is_authenticated %}
+        <section class="s-section">
+            <div class="s-section__container container">
+                <div class="s-section__row row mb-1 mb-md-3">
+                    <div class="s-section__col col-6">
+                        <a href="{% url 'event:calendar' %}" class="btn btn-primary btn-block">
+                            Accéder aux évènements publics
+                        </a>
+                    </div>
+                </div>
+            </div>
+        </section>
+    {% endif %}
+
+
 {% endblock %}
 
 {% block extra_js %}

--- a/lacommunaute/templates/pages/home.html
+++ b/lacommunaute/templates/pages/home.html
@@ -32,7 +32,7 @@
                     </div>
                 </div>
                 <div class="s-page-menu-01__row row">
-                    <div class="s-page-menu-01__col s-page-menu-01__col--title col-12 col-md-8 mt-3 mt-md-5">
+                    <div class="s-page-menu-01__col s-page-menu-01__col--title col-12 col-lg-8 mt-3 mt-lg-5">
                         <h2 class="h1 mb-3 mb-lg-5">Accédez aux groupes de travail et discussions</h2>
 
                         <ul class="lead list-unstyled mb-md-5">
@@ -50,21 +50,21 @@
                             </li>
                         </ul>
                         <div class="row">
-                            <div class="col-12 col-md-auto">
+                            <div class="col-12 col-lg-auto">
                                 <a href="#community" class="btn btn-primary btn-block">
                                     Accéder aux {% trans "Forums"|lower %}
                                 </a>
                             </div>
-                            <div class="col-12 col-md-auto mt-3 mt-md-0">
+                            <div class="col-12 col-lg-auto mt-3 mt-lg-0">
                                 <a href="{% url 'event:calendar' %}" class="btn btn-primary btn-block">
                                     Accéder aux évènements publics
                                 </a>
                             </div>
                         </div>
                     </div>
-                    <div class="s-page-menu-01__col col-12 d-none d-md-inline-flex col-md-4">
+                    <div class="s-page-menu-01__col col-12 d-none d-lg-inline-flex col-md-4">
                         <div>
-                            <img src="{% static 'images/hp-illustration-01.svg' %}" class="img-fluid" alt="">
+                            <img src="{% static 'images/hp-illustration-01.svg' %}" class="img-fluid" loading="lazy" alt="">
                         </div>
                     </div>
                 </div>
@@ -83,16 +83,14 @@
 
         <section class="s-section">
             <div class="s-section__container container">
-                <div class="s-section__row row mb-1 mb-md-3">
+                <div class="s-section__row row">
                     <div class="s-section__col col-12">
                         <p>Nous déployons des communautés publiques et privées.</p>
                         <p>Ces communautés sont co-construites avec et pour les acteurs de l’inclusion en fonction de leurs besoins et de leurs objectifs. <br> Cliquez sur une communauté ci-dessous pour consulter les sujets en cours. Pour contribuer, connectez-vous avec Inclusion Connect.</p>
                     </div>
-                </div>
-                <div class="s-section__row row mb-1 mb-md-3">
-                    <div class="s-section__col col-12 mt-3 anchor" id="community">
-                        <a href="{% url 'inclusion_connect:authorize' %}" class="btn btn-ico btn-outline-primary">
-                            <i class="ri-login-box-line ri-lg"></i>
+                    <div class="s-section__col col-12 col-lg-auto anchor" id="community">
+                        <a href="{% url 'inclusion_connect:authorize' %}" class="btn btn-block btn-ico btn-outline-primary justify-content-center">
+                            <i class="ri-login-box-line ri-lg" aria-hidden="true"></i>
                             <span>
                                 Je me connecte pour accéder à toutes mes communautés
                             </span>
@@ -102,6 +100,7 @@
             </div>
         </section>
     {% endif %}
+
 
     <section class="s-tabs-01">
         <div class="s-tabs-01__container container">
@@ -128,6 +127,10 @@
                                 Questions en attente
                             </a>
                         </li>
+                        <li class="nav-item-dropdown dropdown">
+                            <a class="nav-link dropdown-toggle" href="#" role="button" id="sTabs01DropdownMoreLink" data-toggle="dropdown" aria-expanded="false"><i class="ri-more-line" aria-hidden="true"></i></a>
+                            <div class="dropdown-menu dropdown-menu-right" aria-labelledby="sTabs01DropdownMoreLink"></div>
+                        </li>
                     </ul>
                     <div class="tab-content">
                         <div class="tab-pane fade{% if forums_tab %} show active{% endif %}" id="forums"
@@ -148,12 +151,11 @@
         </div>
     </section>
 
-
     {% if user.is_authenticated %}
         <section class="s-section">
             <div class="s-section__container container">
                 <div class="s-section__row row mb-1 mb-md-3">
-                    <div class="s-section__col col-6">
+                    <div class="s-section__col col-12 col-lg-auto">
                         <a href="{% url 'event:calendar' %}" class="btn btn-primary btn-block">
                             Accéder aux évènements publics
                         </a>
@@ -162,7 +164,6 @@
             </div>
         </section>
     {% endif %}
-
 
 {% endblock %}
 

--- a/lacommunaute/www/forum_views/tests_views.py
+++ b/lacommunaute/www/forum_views/tests_views.py
@@ -438,6 +438,35 @@ class IndexViewTest(TestCase):
         self.assertEqual(response.status_code, 200)
         self.assertContains(response, self.forum.name)
 
+    def test_form_is_in_context(self):
+        response = self.client.get(self.url)
+        self.assertIsInstance(response.context_data["form"], PostForm)
+
+    def test_unaswered_topics_visibility(self):
+        unanswered_private_topic = TopicFactory(forum=ForumFactory(is_private=True), with_post=True)
+        unanswered_public_topic = TopicFactory(forum=ForumFactory(is_private=False), with_post=True)
+
+        response = self.client.get(self.url)
+
+        self.assertNotIn(unanswered_private_topic, response.context["topics"])
+        self.assertIn(unanswered_public_topic, response.context["topics"])
+
+    def test_parameters_in_url(self):
+        response = self.client.get(self.url)
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(response, 'class="nav-link" id="pending-topics-tab"')
+        self.assertContains(response, 'class="tab-pane fade" id="pending-topics"')
+        self.assertContains(response, 'class="nav-link active" id="forums_tab"')
+        self.assertContains(response, 'class="tab-pane fade show active" id="forums"')
+
+        url = self.url + "?new=1"
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(response, 'class="nav-link active" id="pending-topics-tab"')
+        self.assertContains(response, 'class="tab-pane fade show active" id="pending-topics"')
+        self.assertContains(response, 'class="nav-link" id="forums_tab"')
+        self.assertContains(response, 'class="tab-pane fade" id="forums"')
+
 
 class CreateForumView(TestCase):
     def setUp(self):

--- a/lacommunaute/www/forum_views/views.py
+++ b/lacommunaute/www/forum_views/views.py
@@ -39,6 +39,18 @@ class IndexView(BaseIndexView):
             ),
         )
 
+    def get_context_data(self, **kwargs):
+        context = super().get_context_data(**kwargs)
+        context["topics"] = Topic.objects.unanswered().filter(forum__in=Forum.objects.public())
+        context["form"] = PostForm(user=self.request.user)
+
+        if self.request.GET.get("new", None):
+            context["pending_topics_tab"] = True
+        else:
+            context["forums_tab"] = True
+
+        return context
+
 
 class ForumView(BaseForumView):
     paginate_by = settings.FORUM_TOPICS_NUMBER_PER_PAGE


### PR DESCRIPTION
## Description

🎸 Afficher les questions posées dans les `forum` public, qui n'ont reçues aucune reponse, dans un onglet de la page d'accueil
🎸 Premier cas où des `topic` sont affichés sans qu'aucun `forum` ne soit défini en contexte

## Type de changement

🎢 Nouvelle fonctionnalité (changement non cassant qui ajoute une fonctionnalité).

### Points d'attention

🦺 modification de templates pour gérer les cas (`poster` et `download_permission`) où aucun `forum` n'est passé en contexte
🦺 ajout de `manager` pour obtenir les `topic` non répondus des `forum` public
🦺 ajout d'une `tablist` dans `IndexView`, selon la présence du paramètre `new` dans l'url, l'onglet des questions en attente de réponse est mise en avant à la place de celui de la liste des `forum`

### Captures d'écran (optionnel)

IndexView, paramètre `new` absent de l'url
![image](https://user-images.githubusercontent.com/11419273/229550130-c76b9129-a5bc-428a-8af9-7a1debb1ec9a.png)

IndexView avec le paramètre `new` dans l'url
![image](https://user-images.githubusercontent.com/11419273/229550797-6e5d8696-c6a0-4b99-93d1-49400180a69d.png)

