### PR TITLE
[Stats] automatiser la collecte des stats mensuelles (fixes)

### DIFF
--- a/clevercloud/collect_monthly_matomo_stats.sh
+++ b/clevercloud/collect_monthly_matomo_stats.sh
@@ -15,4 +15,4 @@ fi
 # $APP_HOME is set by default by clever cloud.
 cd $APP_HOME
 
-python manage.py collect_matomo_stats
+python manage.py collect_matomo_stats --period month

--- a/clevercloud/cron.json
+++ b/clevercloud/cron.json
@@ -1,6 +1,6 @@
 [
-    "0 5 * * * $ROOT/clevercloud/collect_matomo_stats.sh",
-    "5 5 1 * * $ROOT/clevercloud/collect_matomo_stats.sh --period month",
+    "0 5 * * * $ROOT/clevercloud/collect_daily_matomo_stats.sh",
+    "5 5 1 * * $ROOT/clevercloud/collect_monthly_matomo_stats.sh",
     "5 7-21 * * * $ROOT/clevercloud/send_notifs_when_first_reply.sh",
     "10 6-22 * * * $ROOT/clevercloud/add_user_to_list_when_register.sh"
 ]

--- a/lacommunaute/forum_stats/management/commands/collect_matomo_stats.py
+++ b/lacommunaute/forum_stats/management/commands/collect_matomo_stats.py
@@ -20,7 +20,12 @@ class Command(BaseCommand):
         from_date = Stat.objects.filter(period=period).order_by("-date").first()
 
         if from_date:
-            from_date = from_date.date + relativedelta(days=1)
+            if period == "day":
+                from_date = from_date.date + relativedelta(days=1)
+            elif period == "week":
+                from_date = from_date.date + relativedelta(days=7)
+            else:
+                from_date = from_date.date + relativedelta(months=1)
         else:
             from_date = date(2022, 12, 1)
 


### PR DESCRIPTION
## Description

🎸 Fixes de la PR #209 

* décaler la date de demarrage de collecte pour les périodes `week` et `month`
* ajustement des scripts et de la crontab

## Type de changement

🪲 Correction de bug (changement non cassant qui corrige un problème).
🚧 technique
