### PR TITLE
FIX: ajout du contexte des questions en attente sur la homepage

### DIFF
--- a/lacommunaute/www/forum_views/tests_views.py
+++ b/lacommunaute/www/forum_views/tests_views.py
@@ -467,6 +467,14 @@ class IndexViewTest(TestCase):
         self.assertContains(response, 'class="nav-link" id="forums_tab"')
         self.assertContains(response, 'class="tab-pane fade" id="forums"')
 
+    def test_has_liked(self):
+        TopicFactory(forum=self.forum, poster=self.user, with_post=True, with_like=True)
+
+        self.client.force_login(self.user)
+        response = self.client.get(self.url)
+        # icon: solid heart
+        self.assertContains(response, '<i class="ri-heart-3-fill" aria-hidden="true"></i><span class="ml-1">1</span>')
+
 
 class CreateForumView(TestCase):
     def setUp(self):


### PR DESCRIPTION
## Description

🎸 Ajout du contexte pour afficher les `like`, les `attachments` et les `votes` sans surcharger la DB

## Type de changement

🪲 Correction de bug (changement non cassant qui corrige un problème).
🚧 technique

### Points d'attention

🦺 factoriser les annotations, les select_related et les prefetch_related