### PR TITLE
Optimisation du fil d'actualités d'une communauté

### DIFF
--- a/lacommunaute/templates/forum_conversation/partials/post_feed.html
+++ b/lacommunaute/templates/forum_conversation/partials/post_feed.html
@@ -12,7 +12,7 @@
             <div class="col-12 post-content-wrapper">
                 <div class="d-flex align-items-center mb-1">
                     <span class="mb-0 flex-grow-1">
-                        {%include "forum_conversation/partials/poster.html" with post=post topic=topic %}
+                        {%include "forum_conversation/partials/poster.html" with post=post topic=topic actions=True %}
                     </span>
                     {% include "forum_conversation/partials/post_upvotes.html"%}
                 </div>

--- a/lacommunaute/templates/forum_conversation/partials/poster.html
+++ b/lacommunaute/templates/forum_conversation/partials/poster.html
@@ -1,9 +1,12 @@
 {% load i18n %}
 {% load forum_member_tags %}
-{% load forum_permission_tags %}
 {% load date_filters %}
 
-{% get_permission 'can_edit_post' post request.user as user_can_edit_post %}
+{% if actions %}
+    {% load forum_permission_tags %}
+    {% get_permission 'can_edit_post' post request.user as user_can_edit_post %}
+{% endif %}
+
 <small class="text-muted">
     {% spaceless %}
         <i class="fas fa-clock"></i>&nbsp;

--- a/lacommunaute/templates/forum_conversation/topic_detail.html
+++ b/lacommunaute/templates/forum_conversation/topic_detail.html
@@ -23,7 +23,7 @@
                     <div class="card-header mb-1 d-flex flex-column flex-md-row align-items-md-center">
                         <p class="h4 mb-0 flex-grow-1">
                             {% if topic.is_locked %}&nbsp;<i class="fas fa-times-circle locked-indicator" aria-label="{% trans 'This topic is locked' %}"></i>{% endif %}
-                            {% include "forum_conversation/partials/poster.html" with post=post topic=topic is_topic_head=True %}
+                            {% include "forum_conversation/partials/poster.html" with post=post topic=topic is_topic_head=True actions=True %}
                         </p>
                         {% block htmx %}
                             {% include "forum_conversation/partials/topic_likes.html" %}
@@ -51,7 +51,7 @@
                         </div>
                     </div>
                 </div>
-                {% include "forum_conversation/partials/posts_list.html" %}
+                {% include "forum_conversation/partials/posts_list.html" with actions=True %}
             </div>
         </div>
     {% endwith %}

--- a/lacommunaute/www/forum_views/tests_views.py
+++ b/lacommunaute/www/forum_views/tests_views.py
@@ -270,7 +270,7 @@ class ForumViewTest(TestCase):
     def test_queries(self):
         TopicFactory.create_batch(20, with_post=True)
         self.client.force_login(self.user)
-        with self.assertNumQueries(29):
+        with self.assertNumQueries(26):
             self.client.get(self.url)
 
     def test_param_new_in_request(self):

--- a/lacommunaute/www/forum_views/views.py
+++ b/lacommunaute/www/forum_views/views.py
@@ -76,13 +76,22 @@ class ForumView(BaseForumView):
             .exclude(approved=False)
             .annotate(likes=Count("likers"))
             .annotate(has_liked=Exists(User.objects.filter(topic_likes=OuterRef("id"), id=self.request.user.id)))
-            .select_related("poster", "poster__forum_profile", "first_post", "forum", "certified_post")
+            .select_related(
+                "poster",
+                "poster__forum_profile",
+                "first_post",
+                "first_post__poster",
+                "forum",
+                "certified_post",
+                "certified_post__post",
+                "certified_post__post__poster",
+            )
             .prefetch_related(
                 "poll",
                 "poll__options",
                 "poll__options__votes",
                 "first_post__attachments",
-                "first_post__poster",
+                "certified_post__post__attachments",
             )
             .order_by("-last_post_on")
         )


### PR DESCRIPTION
## Description

🎸 Le lien `éditer` dans le fil d'actualités de la vue `ForumView` déclenche des requêtes en base pour vérifier si l'utilisateur peut éditer un `Post` et ceux pour chaque `Post`. Pour limiter le nombre de requêtes, et optimiser l'affichage de la page, le lien `éditer` est affiché uniquement dans la vue `TopicView` et lors de l'ajout d'un `post` depuis le fil d'actualités (`PostFeedCreateView`)
🎸 Amélioration des requêtes de `ForumView`

## Type de changement

🚧 technique

### Captures d'écran (optionnel)

Fil d'actualités sans lien "éditer"
![image](https://user-images.githubusercontent.com/11419273/231160525-bed361b4-d4c4-41d6-b2a8-4c0d054189dd.png)

Vue de détail du `topic` avec les liens "éditer"
![image](https://user-images.githubusercontent.com/11419273/231160632-24176f94-c199-4693-9597-0e1cd15d95c5.png)

Ajout d'un `post` depuis le fil d'actualités, avec le lien "éditer"
![image](https://user-images.githubusercontent.com/11419273/231160943-bfda9d88-fd9f-457f-a1e2-09806d6754bd.png)

