### PR TITLE
Désambigüer les actions dans matomo lors de la creation d'un sujet

### DIFF
--- a/lacommunaute/templates/forum/forum_detail.html
+++ b/lacommunaute/templates/forum/forum_detail.html
@@ -33,7 +33,7 @@
                             class="btn btn-primary btn-ico matomo-event"
                             data-matomo-category="engagement"
                             data-matomo-action="contribute"
-                            data-matomo-option="topic">
+                            data-matomo-option="new_topic">
                             <i class="ri-chat-new-line ri-lg"></i>
                             <span>{% trans "New topic" %}</span>
                         </a>

--- a/lacommunaute/templates/forum_conversation/partials/topic_form.html
+++ b/lacommunaute/templates/forum_conversation/partials/topic_form.html
@@ -88,7 +88,7 @@
             <input type="submit" class="btn btn-primary matomo-event" value="{% trans "Submit" %}"
                 data-matomo-category="engagement"
                 data-matomo-action="contribute"
-                data-matomo-option="topic" />
+                data-matomo-option="submit_topic" />
         </div>
         {% if post %}
             {% get_permission 'can_delete_post' post request.user as user_can_delete_post %}


### PR DESCRIPTION
## Description

🎸 Deux liens sont comptés dans la meme action matomo : l'accès au formulaire de création d'un `topic` et la soumission de ce formulaire. 
🎸 Modification de `data-matomo-option` pour ces 2 liens

## Type de changement

🪲 Correction de bug (changement non cassant qui corrige un problème).

