### PR TITLE
Liste des dernières réponses certifiées

### DIFF
--- a/lacommunaute/templates/pages/home.html
+++ b/lacommunaute/templates/pages/home.html
@@ -130,6 +130,24 @@
                                 Questions en attente
                             </a>
                         </li>
+                        <li class="nav-item" role="presentation">
+                            <a id="certified-topics-tab"
+                                data-toggle="tab"
+                                href="#certified-topics"
+                                role="tab"
+                                aria-controls="certified-topics"
+                                aria-selected="false"
+                                hx-target="#certifiedtopicsarea"
+                                hx-swap="outerHTML"
+                                hx-get="{% url 'forum_conversation_extension:public_certified_topics_list' %}"
+                                hx-trigger="load"
+                                class="nav-link matomo-event"
+                                data-matomo-category="engagement"
+                                data-matomo-action="loadmore"
+                                data-matomo-option="certified_topic">
+                                Réponses certifiées
+                            </a>
+                        </li>
                         <li class="nav-item-dropdown dropdown">
                             <a class="nav-link dropdown-toggle" href="#" role="button" id="sTabs01DropdownMoreLink" data-toggle="dropdown" aria-expanded="false"><i class="ri-more-line" aria-hidden="true"></i></a>
                             <div class="dropdown-menu dropdown-menu-right" aria-labelledby="sTabs01DropdownMoreLink"></div>
@@ -147,6 +165,13 @@
                             {% with topics=topics topic_list_title="Questions en attente" %}
                                 {% include "forum_conversation/topic_list.html" %}
                             {% endwith %}
+                        </div>
+                        <div class="tab-pane fade" id="certified-topics"
+                            role="tabpanel"
+                            aria-labelledby="certified-topics-tab">
+                            <div id="certifiedtopicsarea">
+                                chargement en cours...
+                            </div>
                         </div>
                     </div>
                 </div>

--- a/lacommunaute/www/forum_conversation_views/urls.py
+++ b/lacommunaute/www/forum_conversation_views/urls.py
@@ -4,6 +4,7 @@ from lacommunaute.www.forum_conversation_views.views import (
     ForumTopicListView,
     PostFeedCreateView,
     PostListView,
+    TopicCertifiedListView,
     TopicCertifiedPostView,
     TopicContentView,
     TopicLikeView,
@@ -21,9 +22,17 @@ conversation_urlpatterns = [
     path("topic/", ForumTopicListView.as_view(), name="topic_list"),
 ]
 
+public_topics_urlpatterns = [
+    path("topic/certified/", TopicCertifiedListView.as_view(), name="public_certified_topics_list"),
+]
+
 urlpatterns = [
     path(
         "forum/<str:forum_slug>-<int:forum_pk>/",
         include(conversation_urlpatterns),
+    ),
+    path(
+        "public/",
+        include(public_topics_urlpatterns),
     ),
 ]

--- a/lacommunaute/www/forum_conversation_views/views.py
+++ b/lacommunaute/www/forum_conversation_views/views.py
@@ -115,6 +115,23 @@ class TopicContentView(PermissionRequiredMixin, View):
         return self.get_topic().forum
 
 
+class TopicCertifiedListView(ListView):
+    template_name = "forum_conversation/topic_list.html"
+
+    paginate_by = paginate_by = settings.FORUM_TOPICS_NUMBER_PER_PAGE
+    context_object_name = "topics"
+
+    def get_queryset(self):
+        return Topic.objects.filter(
+            forum__in=Forum.objects.public(), certified_post__isnull=False
+        ).optimized_for_topics_list(self.request.user.id)
+
+    def get_context_data(self, **kwargs):
+        context = super().get_context_data(**kwargs)
+        context["loadmoretopic_url"] = reverse("forum_conversation_extension:public_certified_topics_list")
+        return context
+
+
 class TopicCertifiedPostView(TopicContentView):
     template = "forum_conversation/partials/topic_certified_post.html"
 

--- a/lacommunaute/www/forum_views/tests_views.py
+++ b/lacommunaute/www/forum_views/tests_views.py
@@ -527,6 +527,11 @@ class IndexViewTest(TestCase):
         # icon: solid heart
         self.assertContains(response, '<i class="ri-heart-3-fill" aria-hidden="true"></i><span class="ml-1">1</span>')
 
+    def test_certified_topics_list_is_preloaded(self):
+        response = self.client.get(self.url)
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(response, 'hx-trigger="load"')
+
 
 class CreateForumView(TestCase):
     def setUp(self):


### PR DESCRIPTION
## Description

🎸 Afficher la liste des dernières réponses certifiées dans un onglet dedié de la page d'accueil de la communauté
🎸 Précharger cette liste avec le tag `hx-trigger="load"` pour réduire le délai d'affichage lors du clic sur l'onglet sans ralentir le chargement de la page d'accueil

## Type de changement

🎢 Nouvelle fonctionnalité (changement non cassant qui ajoute une fonctionnalité).

### Points d'attention

🦺 Les réponses certifiées étant liées à des `forum` public, tous les utilisateurs (même non loggés) peuvent contribuer. La gestion des droits n'est pas implémentée (perf)

### Captures d'écran (optionnel)

![image](https://user-images.githubusercontent.com/11419273/231192067-ac4d3f25-a55f-4c62-aae1-234de42252fe.png)
