### PR TITLE
[FIX] rendre le markdown et les url cliquables compatibles

### DIFF
--- a/lacommunaute/templates/forum_conversation/partials/post_certified.html
+++ b/lacommunaute/templates/forum_conversation/partials/post_certified.html
@@ -19,7 +19,7 @@
                         </div>
                     </div>
                     <div class="post-content" id="showmorecertifiedpostsarea{{topic.pk}}">
-                        {{ post.content.rendered|urlizetrunc_target_blank:30|truncatechars:200 }}
+                        {{ post.content.rendered|urlizetrunc_target_blank:30|img_fluid|truncatechars_html:200 }}
                         {% if post.content.rendered|length > 200 %}
                             <a hx-get="{% url 'forum_conversation_extension:showmore_certified' topic.forum.slug topic.forum.pk topic.slug topic.pk %}"
                                 id="showmorecertified-button{{topic.pk}}"

--- a/lacommunaute/templates/forum_conversation/partials/post_feed.html
+++ b/lacommunaute/templates/forum_conversation/partials/post_feed.html
@@ -17,7 +17,7 @@
                     {% include "forum_conversation/partials/post_upvotes.html"%}
                 </div>
                 <div class="post-content">
-                    {{ post.content.rendered|urlizetrunc_target_blank:30}}
+                    {{ post.content.rendered|urlizetrunc_target_blank:30|img_fluid}}
                     {% include "forum_conversation/forum_attachments/attachments_images.html" %}
                 </div>
                 {% include "forum_conversation/forum_attachments/attachments_detail.html" with post=post user_can_download_files=user_can_download_files %}

--- a/lacommunaute/templates/forum_conversation/partials/posts_list.html
+++ b/lacommunaute/templates/forum_conversation/partials/posts_list.html
@@ -24,7 +24,7 @@
                             </div>
                         </div>
                         <div class="post-content">
-                            {{ post.content.rendered|urlizetrunc_target_blank:30}}
+                            {{ post.content.rendered|urlizetrunc_target_blank:30|img_fluid}}
                             {% include "forum_conversation/forum_attachments/attachments_images.html" %}
                         </div>
                         {% include "forum_conversation/forum_attachments/attachments_detail.html" with post=post user_can_download_files=user_can_download_files %}

--- a/lacommunaute/templates/forum_conversation/partials/topic_certified_post.html
+++ b/lacommunaute/templates/forum_conversation/partials/topic_certified_post.html
@@ -1,3 +1,3 @@
 {% load str_filters %}
 
-{{ topic.certified_post.post.content.rendered|urlizetrunc_target_blank:30 }}
+{{ topic.certified_post.post.content.rendered|urlizetrunc_target_blank:30|img_fluid }}

--- a/lacommunaute/templates/forum_conversation/partials/topic_content.html
+++ b/lacommunaute/templates/forum_conversation/partials/topic_content.html
@@ -1,3 +1,3 @@
 {% load str_filters %}
 
-{{topic.first_post.content.rendered|urlizetrunc_target_blank:30}}
+{{topic.first_post.content.rendered|urlizetrunc_target_blank:30|img_fluid}}

--- a/lacommunaute/templates/forum_conversation/topic_detail.html
+++ b/lacommunaute/templates/forum_conversation/topic_detail.html
@@ -32,7 +32,7 @@
                     <div class="card-body pt-0 ">
                         <div class="row">
                             <div class="col-12 col-lg-11 post-content">
-                                {{ post.content.rendered|urlizetrunc_target_blank:30}}
+                                {{ post.content.rendered|urlizetrunc_target_blank:30|img_fluid}}
                                 {% include "forum_conversation/forum_attachments/attachments_images.html" %}
                             </div>
                             <div class="col-12 post-content-wrapper">

--- a/lacommunaute/templates/forum_conversation/topic_list.html
+++ b/lacommunaute/templates/forum_conversation/topic_list.html
@@ -4,6 +4,7 @@
 {% load forum_member_tags %}
 {% load forum_tracking_tags %}
 {% load forum_permission_tags %}
+{% load str_filters %}
 
 {% if forum %}
     {% get_permission 'can_download_files' forum request.user as user_can_download_files %}
@@ -57,7 +58,7 @@
                                             </div>
                                             <div class="col-12 post-content">
                                                 <div id="showmoretopicsarea{{topic.pk}}">
-                                                    {{ topic.first_post.content.rendered|urlize|truncatechars:200 }}
+                                                    {{ topic.first_post.content.rendered|urlizetrunc_target_blank:30|img_fluid|truncatechars_html:200 }}
                                                     {% if topic.first_post.content.rendered|length > 200 %}
                                                         <a hx-get="{% url 'forum_conversation_extension:showmore_topic' topic.forum.slug topic.forum.pk topic.slug topic.pk %}"
                                                             id="showmoretopic-button{{topic.pk}}"

--- a/lacommunaute/utils/templatetags/str_filters.py
+++ b/lacommunaute/utils/templatetags/str_filters.py
@@ -49,3 +49,9 @@ def urlizetrunc_target_blank(value, limit, autoescape=True):
     """
     urlized = _urlize(value, trim_url_limit=int(limit), nofollow=True, autoescape=autoescape)
     return mark_safe(urlized.replace("<a ", '<a target="_blank" '))
+
+
+@register.filter(is_safe=True)
+@stringfilter
+def img_fluid(value):
+    return mark_safe(value.replace("<img ", '<img class="img-fluid" '))

--- a/lacommunaute/utils/templatetags/str_filters.py
+++ b/lacommunaute/utils/templatetags/str_filters.py
@@ -4,9 +4,10 @@ https://docs.djangoproject.com/en/dev/howto/custom-template-tags/
 from django import template
 from django.template.defaultfilters import stringfilter
 from django.urls import reverse
-from django.utils.html import urlize as _urlize
 from django.utils.http import urlencode
 from django.utils.safestring import mark_safe
+
+from lacommunaute.utils.urls import urlize
 
 
 register = template.Library()
@@ -47,7 +48,7 @@ def urlizetrunc_target_blank(value, limit, autoescape=True):
 
     Argument: Length to truncate URLs to.
     """
-    urlized = _urlize(value, trim_url_limit=int(limit), nofollow=True, autoescape=autoescape)
+    urlized = urlize(value, trim_url_limit=int(limit), nofollow=True, autoescape=autoescape)
     return mark_safe(urlized.replace("<a ", '<a target="_blank" '))
 
 

--- a/lacommunaute/utils/tests.py
+++ b/lacommunaute/utils/tests.py
@@ -142,11 +142,14 @@ class UtilsTemplateTagsTestCase(TestCase):
         self.assertEqual(out, f"le {date(d)}, {time(d)}")
 
     def test_urlizetrunc_target_blank(self):
-        template = Template("{% load str_filters %}{{ url|urlizetrunc_target_blank:16 }}")
-        out = template.render(Context({"url": "www.neuralia.co/mission"}))
+        template = Template("{% load str_filters %}{{ str|urlizetrunc_target_blank:16 }}")
+        out = template.render(Context({"str": "www.neuralia.co/mission"}))
         self.assertEqual(
             out, '<a target="_blank" href="http://www.neuralia.co/mission" rel="nofollow">www.neuralia.co…</a>'
         )
+
+        out = template.render(Context({"str": 'src="www.neuralia.co/image.png"'}))
+        self.assertEqual(out, "src=&quot;www.neuralia.co/image.png&quot;")
 
     def test_img_fluid(self):
         template = Template("{% load str_filters %}{{ html|img_fluid }}")

--- a/lacommunaute/utils/tests.py
+++ b/lacommunaute/utils/tests.py
@@ -135,6 +135,11 @@ class UtilsTemplateTagsTestCase(TestCase):
             out, '<a target="_blank" href="http://www.neuralia.co/mission" rel="nofollow">www.neuralia.co…</a>'
         )
 
+    def test_img_fluid(self):
+        template = Template("{% load str_filters %}{{ html|img_fluid }}")
+        out = template.render(Context({"html": '<img src="image.png">'}))
+        self.assertEqual(out, '<img class="img-fluid" src="image.png">')
+
 
 class UtilsStatsTest(TestCase):
     def test_get_strftime(self):

--- a/lacommunaute/utils/tests.py
+++ b/lacommunaute/utils/tests.py
@@ -25,6 +25,7 @@ from lacommunaute.utils.stats import (
     format_counts_of_objects_for_timeline_chart,
     get_strftime,
 )
+from lacommunaute.utils.urls import urlize
 
 
 faker = Faker()
@@ -86,6 +87,18 @@ class SettingsContextProcessorsTest(TestCase):
         response = self.client.get("/", headers=headers)
         self.assertEqual(response.status_code, 200)
         self.assertTrue(hasattr(response.wsgi_request, "htmx"))
+
+
+class UtilsUrlsTestCase(TestCase):
+    def test_urlize(self):
+        url = f"{faker.url()}/long_string_to_truncate/"
+        self.assertEqual(urlize(url, trim_url_limit=10), f'<a href="{url}">{url[:9]}…</a>')
+
+        link = f'<a href="{faker.url()}">{faker.name()}</a>'
+        self.assertEqual(urlize(link), link)
+
+        img = f'<img src="{faker.url()}">'
+        self.assertEqual(urlize(img), img)
 
 
 class UtilsTemplateTagsTestCase(TestCase):

--- a/lacommunaute/utils/urls.py
+++ b/lacommunaute/utils/urls.py
@@ -1,5 +1,33 @@
+import re
+
 from django.conf import settings
+from django.utils.functional import keep_lazy_text
+from django.utils.html import Urlizer as BaseUrlizer
 from django.utils.http import url_has_allowed_host_and_scheme
+from django.utils.regex_helper import _lazy_re_compile
+
+
+class Urlizer(BaseUrlizer):
+    """
+    override django.utils.html.Urlizer to fix conflict between markdown and urlize
+    """
+
+    # do not split string from its leading/trailing double quote,
+    # to keep markdown link rendered in html (src="www.example.com" and href="www.example.com")
+    word_split_re = _lazy_re_compile(r"""([\s<>']+)""")
+
+    # do not consider string containing src= or href= as url
+    simple_url_2_re = _lazy_re_compile(
+        r"^www\.|^(?!http|src=|href=)\w[^@]+\.(com|edu|gov|int|mil|net|org|fr)($|/.*)$", re.IGNORECASE
+    )
+
+
+urlizer = Urlizer()
+
+
+@keep_lazy_text
+def urlize(text, trim_url_limit=None, nofollow=False, autoescape=False):
+    return urlizer(text, trim_url_limit=trim_url_limit, nofollow=nofollow, autoescape=autoescape)
 
 
 def get_safe_url(request, param_name=None, fallback_url=None, url=None):

--- a/lacommunaute/www/forum_views/tests_views.py
+++ b/lacommunaute/www/forum_views/tests_views.py
@@ -1,5 +1,5 @@
 from django.contrib.auth.models import AnonymousUser, Group
-from django.template.defaultfilters import truncatechars
+from django.template.defaultfilters import truncatechars_html
 from django.test import RequestFactory, TestCase, override_settings
 from django.urls import reverse
 from django.utils.http import urlencode
@@ -305,7 +305,7 @@ class ForumViewTest(TestCase):
         response = self.client.get(self.url)
 
         self.assertEqual(response.status_code, 200)
-        self.assertNotContains(response, truncatechars(post.content.rendered, 200))
+        self.assertNotContains(response, truncatechars_html(post.content.rendered, 200))
         self.assertNotContains(response, topic_certified_post_url)
         self.assertNotContains(response, "Certifié par la Plateforme de l'Inclusion")
 
@@ -315,7 +315,7 @@ class ForumViewTest(TestCase):
         response = self.client.get(self.url)
 
         self.assertEqual(response.status_code, 200)
-        self.assertContains(response, truncatechars(post.content.rendered, 200))
+        self.assertContains(response, truncatechars_html(post.content.rendered, 200))
         self.assertContains(response, topic_certified_post_url)
         self.assertContains(response, "Certifié par la Plateforme de l'Inclusion")
 


### PR DESCRIPTION
## Description

🎸 L `urlizer` générait un conflit avec le rendu des liens et des images en markdown.
🎸 Surcharge de l `urlizer` pour ignorer les liens déjà intégrés dans des tags html
🎸 Uniformisation des templates de rendus de `post` et de `topic` : ajout de `img-fluid`, et remplace de `truncatechars` par `truncatechars_html`

## Type de changement

🪲 Correction de bug (changement non cassant qui corrige un problème).
🚧 technique

### Captures d'écran (optionnel)

![image](https://user-images.githubusercontent.com/11419273/232805003-104a5617-6018-4c31-868a-6c007e390057.png).

après "voir plus"
![image](https://user-images.githubusercontent.com/11419273/232805134-d92eb4f4-763f-491c-b7c8-25686fcc18ae.png)

version edition du message en MD
![image](https://user-images.githubusercontent.com/11419273/232805372-096ad894-27f9-4947-9770-afda9c443960.png)

