### PR TITLE
[fix] affichage de l'avatar dans la liste des questions en attente

### DIFF
--- a/lacommunaute/templates/forum_conversation/topic_list.html
+++ b/lacommunaute/templates/forum_conversation/topic_list.html
@@ -1,4 +1,3 @@
-<!-- template appelé par forum_detail.html -->
 {% load i18n %}
 {% load forum_conversation_tags %}
 {% load forum_member_tags %}

--- a/lacommunaute/templates/pages/home.html
+++ b/lacommunaute/templates/pages/home.html
@@ -135,7 +135,7 @@
                             <div class="dropdown-menu dropdown-menu-right" aria-labelledby="sTabs01DropdownMoreLink"></div>
                         </li>
                     </ul>
-                    <div class="tab-content">
+                    <div class="tab-content topiclist">
                         <div class="tab-pane fade{% if forums_tab %} show active{% endif %}" id="forums"
                             role="tabpanel"
                             aria-labelledby="forums_tab">


### PR DESCRIPTION
## Description

🎸 ajout de la classe `topiclist` dans le `tab-content` de la page d'accueil pour afficher l'avatar en thumbnail dans la liste des questions en attente

## Type de changement

🪲 Correction de bug (changement non cassant qui corrige un problème).

### Captures d'écran (optionnel)

![image](https://user-images.githubusercontent.com/11419273/233054313-8a4bb4c9-451d-4475-889b-2f8838ba006a.png)
