### PR TITLE
[TAGS] etape 1 - ajout des Tags lors de la creation/mise à jour d'un Topics

### DIFF
--- a/lacommunaute/forum_conversation/forms.py
+++ b/lacommunaute/forum_conversation/forms.py
@@ -1,7 +1,9 @@
+from django.core.exceptions import ObjectDoesNotExist
 from django.db.models import F
-from django.forms import CharField, HiddenInput
-from machina.apps.forum_conversation.forms import PostForm as AbstractPostForm
+from django.forms import CharField, CheckboxSelectMultiple, HiddenInput, ModelMultipleChoiceField
+from machina.apps.forum_conversation.forms import PostForm as AbstractPostForm, TopicForm as AbstractTopicForm
 from machina.conf import settings as machina_settings
+from taggit.models import Tag
 
 
 class PostForm(AbstractPostForm):
@@ -18,3 +20,23 @@ class PostForm(AbstractPostForm):
         else:
             post.updated_by = self.user
         post.updates_count = F("updates_count") + 1
+
+
+class TopicForm(AbstractTopicForm):
+    tags = ModelMultipleChoiceField(
+        label="", queryset=Tag.objects.all(), widget=CheckboxSelectMultiple, required=False
+    )
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        try:
+            if hasattr(self.instance, "topic"):
+                self.fields["tags"].initial = self.instance.topic.tags.all()
+        except ObjectDoesNotExist:
+            pass
+
+    def save(self):
+        post = super().save()
+        post.topic.tags.set(self.cleaned_data["tags"])
+        post.topic.save()
+        return post

--- a/lacommunaute/forum_conversation/tests/tests_forms.py
+++ b/lacommunaute/forum_conversation/tests/tests_forms.py
@@ -4,15 +4,13 @@ from django.forms import HiddenInput
 from django.test import TestCase
 from faker import Faker
 from machina.conf import settings as machina_settings
-from machina.core.db.models import get_model
 
 from lacommunaute.forum_conversation.factories import PostFactory, TopicFactory
 from lacommunaute.forum_conversation.forms import PostForm
+from lacommunaute.forum_conversation.models import Post
 
 
 faker = Faker()
-
-Post = get_model("forum_conversation", "Post")
 
 
 class PostFormTest(TestCase):

--- a/lacommunaute/forum_conversation/views.py
+++ b/lacommunaute/forum_conversation/views.py
@@ -5,7 +5,7 @@ from django.urls import reverse
 from machina.apps.forum_conversation import views
 from machina.core.loading import get_class
 
-from lacommunaute.forum_conversation.forms import PostForm
+from lacommunaute.forum_conversation.forms import PostForm, TopicForm
 from lacommunaute.forum_conversation.shortcuts import get_posts_of_a_topic_except_first_one
 from lacommunaute.forum_upvote.shortcuts import can_certify_post
 
@@ -35,6 +35,8 @@ class FormValidMixin:
 
 
 class TopicCreateView(SuccessUrlMixin, FormValidMixin, views.TopicCreateView):
+    post_form_class = TopicForm
+
     def form_valid(self, *args, **kwargs):
         valid = super().form_valid(*args, **kwargs)
         if self.request.user.is_authenticated:
@@ -43,7 +45,7 @@ class TopicCreateView(SuccessUrlMixin, FormValidMixin, views.TopicCreateView):
 
 
 class TopicUpdateView(SuccessUrlMixin, FormValidMixin, views.TopicUpdateView):
-    pass
+    post_form_class = TopicForm
 
 
 class PostCreateView(views.PostCreateView):

--- a/lacommunaute/templates/forum_conversation/partials/topic_form.html
+++ b/lacommunaute/templates/forum_conversation/partials/topic_form.html
@@ -20,6 +20,7 @@
     <!-- Sub "forms" tabs -->
     {% if poll_option_formset or attachment_formset %}
         <ul class="nav nav-tabs nav-tabs--communaute border-bottom-0">
+            <li class="nav-item"><a href="#tags" class="nav-link" data-toggle="tab">{% trans "Tags" %}</a></li>
             {% if attachment_formset %}<li class="nav-item"><a href="#attachments" class="nav-link" data-toggle="tab">{% trans "Attachments" %}</a></li>{% endif %}
             {% if poll_option_formset %}<li class="nav-item"><a href="#poll" class="nav-link" data-toggle="tab">{% trans "Poll" %}</a></li>{% endif %}
         </ul>
@@ -40,6 +41,13 @@
                             {% endwith %}
                         </div>
                     {% endif %}
+                </div>
+            </div>
+        </div>
+        <div class="tab-pane" id="tags">
+            <div class="row">
+                <div id="tags_formset" class="col-md-12">
+                    {% include "partials/form_field.html" with field=post_form.tags %}
                 </div>
             </div>
         </div>

--- a/lacommunaute/templates/partials/form_field.html
+++ b/lacommunaute/templates/partials/form_field.html
@@ -3,7 +3,18 @@
 
 <div id="div_id_{{ field.html_name }}" class="form-group{% if field.errors %} has-error{% endif %}">
     {% if field.label %}<label class="control-label" for="{{ field.auto_id }}">{{ field.label }}{% if not field.field.required %} <span class="text-muted">{% trans "(optional)" %}</span>{% endif %}</label>{% endif %}
-    {{ field | add_class:'form-control' }}
+    {%if field|widget_type == "checkboxselectmultiple"%}
+        {% for checkbox in field %}
+            <div class="custom-control custom-checkbox custom-control-inline">
+                <input id="{{ checkbox.id_for_label }}" class="custom-control-input" type="checkbox" name="{{ checkbox.data.name }}" value="{{ checkbox.data.value }}"{% if checkbox.data.selected %} checked=""{% endif %}>
+                <label class="custom-control-label" for="{{ checkbox.id_for_label }}">
+                    {{ checkbox.choice_label }}
+                </label>
+            </div>
+        {% endfor %}
+    {% else %}
+        {{ field | add_class:'form-control' }}
+    {% endif %}
     {% if field.help_text %}<small class="form-text text-muted">{{ field.help_text }}</small>{% endif %}
     {% for error in field.errors %}<span class="text-danger error">{{ error }}</span>{% endfor %}
     {% if field.auto_id == 'id_content' %}

--- a/lacommunaute/templates/partials/form_field.html
+++ b/lacommunaute/templates/partials/form_field.html
@@ -7,7 +7,7 @@
         {% for checkbox in field %}
             <div class="custom-control custom-checkbox custom-control-inline">
                 <input id="{{ checkbox.id_for_label }}" class="custom-control-input" type="checkbox" name="{{ checkbox.data.name }}" value="{{ checkbox.data.value }}"{% if checkbox.data.selected %} checked=""{% endif %}>
-                <label class="custom-control-label" for="{{ checkbox.id_for_label }}">
+                <label class="custom-control-label badge badge-sm badge-pill badge-info-lighter text-info" for="{{ checkbox.id_for_label }}">
                     {{ checkbox.choice_label }}
                 </label>
             </div>


### PR DESCRIPTION
## Description

🎸 Permettre la sélection d'un ou plusieurs tags lors de la création et de la mise à jour d'un `topic`
🎸 Gestion des `checkboxselectmultiple`

## Type de changement

🎢 Nouvelle fonctionnalité (changement non cassant qui ajoute une fonctionnalité).

### Points d'attention

🦺 surcharge de la classe `TopicForm` de `machina` : ajout du `ModelMultipleChoiceField`, enrichissement de la méthode `save` et initialisation des `tags` déjà sélectionnés en mise à jour
🦺 suite de la PR #225 

### Captures d'écran (optionnel)

Nouveau Topic
![image](https://user-images.githubusercontent.com/11419273/235920193-03429cbf-ce21-4652-884d-d6624501fbaf.png)

Topic après enregistrement
![image](https://user-images.githubusercontent.com/11419273/235920335-60aee262-1463-4f1d-bb62-f9160f79a4eb.png)

Mise à jour du Topic
![image](https://user-images.githubusercontent.com/11419273/235920558-a8accd6b-001b-4179-b194-6c2d89b534bd.png)

Topic après mise à jour
![image](https://user-images.githubusercontent.com/11419273/235920760-e3bfc5f6-2f87-4b21-a530-5fcac91742d1.png)
