### PR TITLE
261 prefetch tags dans optimized for topics list

### DIFF
--- a/lacommunaute/forum_conversation/models.py
+++ b/lacommunaute/forum_conversation/models.py
@@ -39,6 +39,7 @@ class TopicQuerySet(models.QuerySet):
                 "poll__options__votes",
                 "first_post__attachments",
                 "certified_post__post__attachments",
+                "tags",
             )
             .order_by("-last_post_on")
         )

--- a/lacommunaute/forum_conversation/tests/tests_views.py
+++ b/lacommunaute/forum_conversation/tests/tests_views.py
@@ -113,8 +113,7 @@ class TopicCreateViewTest(TestCase):
         self.assertEqual(0, topic.likers.count())
 
     def test_tags_checkbox_are_displayed(self):
-        Tag.objects.create(name=faker.word())
-        Tag.objects.create(name=faker.word())
+        Tag.objects.bulk_create([Tag(name=f"tag_x{i}", slug=f"tag_x{i}") for i in range(2)])
         assign_perm("can_start_new_topics", self.poster, self.forum)
         self.client.force_login(self.poster)
         response = self.client.get(self.url)
@@ -123,9 +122,7 @@ class TopicCreateViewTest(TestCase):
         self.assertContains(response, Tag.objects.last().name)
 
     def test_checked_tags_are_saved(self):
-        Tag.objects.create(name=faker.word())
-        Tag.objects.create(name=faker.word())
-        Tag.objects.create(name=faker.word())
+        Tag.objects.bulk_create([Tag(name=f"tag_y{i}", slug=f"tag_y{i}") for i in range(3)])
         assign_perm("can_start_new_topics", self.poster, self.forum)
         self.client.force_login(self.poster)
 


### PR DESCRIPTION
## Description

🎸 prefetch des objets `tags` dans la méthode `optimized_for_topics_list` 
🎸 amélioration de tests sur les `tags`

## Type de changement

🚧 technique

