### PR TITLE
[FIX] Ne pas envoyer de notification si aucune question en attente

### DIFF
--- a/lacommunaute/forum_conversation/tests/tests_views_htmx.py
+++ b/lacommunaute/forum_conversation/tests/tests_views_htmx.py
@@ -86,7 +86,7 @@ class ForumTopicListViewTest(TestCase):
         assign_perm("can_read_forum", self.user, self.topic.forum)
         self.client.force_login(self.user)
 
-        with self.assertNumQueries(15):
+        with self.assertNumQueries(24):
             self.client.get(self.url)
 
 

--- a/lacommunaute/notification/tasks.py
+++ b/lacommunaute/notification/tasks.py
@@ -43,9 +43,10 @@ def send_notifs_on_unanswered_topics(list_id: int) -> None:
 
         params = {"count": count, "link": link}
 
-        send_email(
-            to=contacts,
-            params=params,
-            template_id=settings.SIB_UNANSWERED_QUESTION_TEMPLATE,
-            kind=EmailSentTrackKind.PENDING_TOPIC,
-        )
+        if count > 0:
+            send_email(
+                to=contacts,
+                params=params,
+                template_id=settings.SIB_UNANSWERED_QUESTION_TEMPLATE,
+                kind=EmailSentTrackKind.PENDING_TOPIC,
+            )

--- a/lacommunaute/notification/tests/tests_tasks.py
+++ b/lacommunaute/notification/tests/tests_tasks.py
@@ -140,3 +140,9 @@ class SendNotifsOnUnansweredTopics(TestCase):
         self.assertEqual(email_sent_track.status_code, 200)
         self.assertEqual(email_sent_track.response, json.dumps({"message": "OK"}))
         self.assertEqual(email_sent_track.datas, payload)
+
+    @respx.mock
+    def test_send_notifs_on_unanswered_topics_with_no_topic(self):
+        send_notifs_on_unanswered_topics(self.list_id)
+
+        self.assertEqual(EmailSentTrack.objects.count(), 0)


### PR DESCRIPTION

## Description

🎸 Ne pas envoyer de notification si aucune question en attente de réponse

## Type de changement

🪲 Correction de bug (changement non cassant qui corrige un problème).

### Points d'attention

🦺 Décision d'architecture
