### PR TITLE
Correction de l’erreur de pluriel dans le compteur de sujets et de messages

### DIFF
--- a/lacommunaute/static/stylesheets/itou_communaute.scss
+++ b/lacommunaute/static/stylesheets/itou_communaute.scss
@@ -133,3 +133,8 @@
   background-color: transparent !important;
   border: 0 !important;
 }
+
+#communautesDropdown.dropdown-menu {
+  max-height: 75vh;
+  overflow-y: auto;
+}

--- a/lacommunaute/templates/forum/forum_list.html
+++ b/lacommunaute/templates/forum/forum_list.html
@@ -57,10 +57,20 @@
                                                 {{ child.obj.name }}
                                             </a>
                                             <small class="text-muted">
-                                                {% if node.obj.is_private%}
-                                                    <i class="ri-lock-2-fill"></i> {{node.obj.members_group.user_set.count}} membres -
+                                                {% if node.obj.is_private %}
+                                                    <i class="ri-lock-2-fill"></i> {{node.obj.members_group.user_set.count}} Membres -
                                                 {% endif %}
-                                                {{child.topics_count}} {% trans "Topics" %} - {{child.posts_count}} {% trans "Posts" %}
+                                                {% if child.topics_count > 1 %}
+                                                    {{ child.topics_count }} {% trans "Topics" %}
+                                                {% else %}
+                                                    {{ child.topics_count }} {% trans "Topic" %}
+                                                {% endif %}
+                                                -
+                                                {% if child.posts_count > 1 %}
+                                                    {{ child.posts_count }} {% trans "Posts" %}
+                                                {% else %}
+                                                    {{ child.posts_count }} {% trans "Post" %}
+                                                {% endif %}
                                             </small>
                                         </div>
                                     </li>
@@ -87,7 +97,17 @@
                             {% if node.obj.is_private%}
                                 <i class="ri-lock-2-fill"></i> {{node.obj.members_group.user_set.count}} membres -
                             {% endif %}
-                            {{node.topics_count}} {% trans "Topics" %} - {{node.posts_count}} {% trans "Posts" %}
+                            {% if node.topics_count > 1 %}
+                                {{ node.topics_count }} {% trans "Topics" %}
+                            {% else %}
+                                {{ node.topics_count }} {% trans "Topic" %}
+                            {% endif %}
+                            -
+                            {% if node.posts_count > 1 %}
+                                {{ node.posts_count }} {% trans "Posts" %}
+                            {% else %}
+                                {{ node.posts_count }} {% trans "Post" %}
+                            {% endif %}
                         </small>
                     </div>
                 </li>

--- a/lacommunaute/templates/forum/partials/topics_and_members_counts.html
+++ b/lacommunaute/templates/forum/partials/topics_and_members_counts.html
@@ -7,6 +7,16 @@
     {% endif %}
     {% if node.obj.is_forum %}
         {% if node.obj.is_private%} - {% endif %}
-        {{node.topics_count}} {% trans "Topics" %} - {{node.posts_count}} {% trans "Posts" %}
+        {% if node.topics_count > 1 %}
+            {{ node.topics_count }} {% trans "Topics" %}
+        {% else %}
+            {{ node.topics_count }} {% trans "Topic" %}
+        {% endif %}
+        -
+        {% if node.posts_count > 1 %}
+            {{ node.posts_count }} {% trans "Posts" %}
+        {% else %}
+            {{ node.posts_count }} {% trans "Post" %}
+        {% endif %}
     {% endif %}
 </small>


### PR DESCRIPTION
## Description

🎸 Correction de l’erreur de pluriel dans le compteur de sujets et de messages
https://www.notion.so/plateforme-inclusion/0-sujets-0-messages-1-sujets-1-messages-d79cf8d80b244be5bcf9db20b2b27688?pvs=4

### Points d'attention

Au passage, fix de la hauteur du dropdown-menu du sous menu de header
