### PR TITLE
Content Security Policies / Permission Policies

### DIFF
--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -84,7 +84,7 @@ LOCAL_APPS = [
 
 INSTALLED_APPS = DJANGO_APPS + LOCAL_APPS + THIRD_PARTIES_APPS
 
-MIDDLEWARE = [
+DJANGO_MIDDLEWARE = [
     "django.middleware.gzip.GZipMiddleware",
     "django.middleware.security.SecurityMiddleware",
     "django.contrib.redirects.middleware.RedirectFallbackMiddleware",
@@ -94,9 +94,19 @@ MIDDLEWARE = [
     "django.contrib.auth.middleware.AuthenticationMiddleware",
     "django.contrib.messages.middleware.MessageMiddleware",
     "django.middleware.clickjacking.XFrameOptionsMiddleware",
+]
+
+THIRD_PARTIES_MIDDLEWARE = [
+    "csp.middleware.CSPMiddleware",
+    "django_permissions_policy.PermissionsPolicyMiddleware",
     "django_htmx.middleware.HtmxMiddleware",
+]
+
+LOCAL_MIDDLEWARE = [
     "machina.apps.forum_permission.middleware.ForumPermissionMiddleware",
 ]
+
+MIDDLEWARE = DJANGO_MIDDLEWARE + THIRD_PARTIES_MIDDLEWARE + LOCAL_MIDDLEWARE
 
 ROOT_URLCONF = "config.urls"
 LOGIN_URL = "/inclusion_connect/authorize"
@@ -341,6 +351,67 @@ SIB_ONBOARDING_LIST = 5
 TAGGIT_CASE_INSENSITIVE = True
 TAGGIT_STRIP_UNICODE_WHEN_SLUGIFY = True
 
+# CSP
+# ---------------------------------------
+CSP_DEFAULT_SRC = ("'self'",)
+# unsafe-inline for htmx.js, embed.js & tartecitron.js needs
+CSP_STYLE_SRC = ("'self'", "https://fonts.googleapis.com", "'unsafe-inline'")
+CSP_STYLE_SRC_ELEM = CSP_STYLE_SRC
+CSP_FONT_SRC = ("'self'", "https://fonts.gstatic.com/", "data:")
+CSP_SCRIPT_SRC = (
+    "'self'",
+    "https://cdn.jsdelivr.net",
+    "https://tally.so",
+)
+CSP_SCRIPT_SRC_ELEM = CSP_SCRIPT_SRC
+CSP_FRAME_SRC = ("'self'", "https://tally.so")
+CSP_IMG_SRC = ("'self'", "data:", "cellar-c2.services.clever-cloud.com")
+CSP_INCLUDE_NONCE_IN = ["script-src", "script-src-elem"]
+
+# HSTS
+# ---------------------------------------
+SECURE_HSTS_SECONDS = 31536000
+SECURE_HSTS_INCLUDE_SUBDOMAINS = True
+SECURE_HSTS_PRELOAD = True
+
+# Clickjacking
+# ---------------------------------------
+X_FRAME_OPTIONS = "DENY"
+
+# SECURITY
+# ---------------------------------------
+# See https://docs.djangoproject.com/en/4.1/topics/security/
+# and https://docs.djangoproject.com/en/4.1/ref/middleware/#module-django.middleware.security
+# See https://docs.djangoproject.com/en/4.1/ref/middleware/#http-strict-transport-security
+
+SECURE_CONTENT_TYPE_NOSNIFF = True
+
+SECURE_HSTS_SECONDS = 31536000
+SECURE_HSTS_INCLUDE_SUBDOMAINS = True
+SECURE_HSTS_PRELOAD = True
+
+SECURE_CROSS_ORIGIN_OPENER_POLICY = "same-origin"
+
 # SESSIONS
 # ---------------------------------------
 SESSION_COOKIE_SECURE = True
+CSRF_COOKIE_SECURE = True
+
+# PERMISSIONS POLICIES
+# ---------------------------------------
+PERMISSIONS_POLICY = {
+    "accelerometer": [],
+    "autoplay": [],
+    "camera": [],
+    "encrypted-media": [],
+    "fullscreen": [],
+    "geolocation": [],
+    "gyroscope": [],
+    "magnetometer": [],
+    "microphone": [],
+    "midi": [],
+    "payment": [],
+    "picture-in-picture": [],
+    "sync-xhr": [],
+    "usb": [],
+}

--- a/lacommunaute/templates/forum_conversation/partials/topic_likes.html
+++ b/lacommunaute/templates/forum_conversation/partials/topic_likes.html
@@ -5,12 +5,12 @@
     {% with topic.likes as counter %}
         {% if user.is_authenticated %}
             <button hx-post="{% url 'forum_conversation_extension:like_topic' topic.forum.slug topic.forum.pk topic.slug topic.pk %}" id="like-button{{topic.pk}}"
-                hx-target="#likesarea{{topic.pk}}"
-                hx-swap="outerHTML"
-                class="btn btn-ico btn-link btn-like px-0 text-nowrap matomo-event"
-                data-matomo-category="engagement"
-                data-matomo-action="like"
-                data-matomo-option="topic"
+                    hx-target="#likesarea{{topic.pk}}"
+                    hx-swap="outerHTML"
+                    class="btn btn-ico btn-link btn-like px-0 text-nowrap matomo-event"
+                    data-matomo-category="engagement"
+                    data-matomo-action="like"
+                    data-matomo-option="topic"
             >
                 <i class="{% if topic.has_liked %}ri-heart-3-fill{% else %}ri-heart-3-line{% endif %} me-1" aria-hidden="true"></i><span>{{counter}}</span>
             </button>

--- a/lacommunaute/templates/forum_conversation/partials/topic_likes.html
+++ b/lacommunaute/templates/forum_conversation/partials/topic_likes.html
@@ -22,6 +22,6 @@
     {% endwith %}
 </div>
 
-<script>
+<script nonce="{{ request.csp_nonce }}">
     document.activeElement?.blur();
 </script>

--- a/lacommunaute/templates/layouts/base.html
+++ b/lacommunaute/templates/layouts/base.html
@@ -13,6 +13,8 @@
             <meta name="keywords" content="{% block meta_keywords %}{% endblock meta_keywords %}">
             <meta name="viewport" content="width=device-width, initial-scale=1">
 
+            <meta name="htmx-config" content='{"inlineScriptNonce":"{{ request.csp_nonce }}"}'>
+
             <!-- https://metatags.io Open Graph -->
             <meta property="og:locale" content="fr_FR">
             <meta property="og:type" content="website">
@@ -103,7 +105,7 @@
         {% block js %}
             {% import_static_JS_theme_inclusion %}
             <script src="{% static 'machina/build/js/machina.min.js' %}" type="text/javascript" charset="utf-8"></script>
-            <script type="text/javascript">
+            <script type="text/javascript" nonce="{{ request.csp_nonce }}">
                 $(function() {
                     machina.init();
                     {% block onbodyload %}{% endblock onbodyload %}
@@ -113,7 +115,7 @@
 
         {% block extra_js %}
             <script src="{% static "vendor/tarteaucitron.js-1.11.0/tarteaucitron.js" %}"></script>
-            <script>
+            <script nonce="{{ request.csp_nonce }}">
                 // Tarteaucitron's language is set according to the browser configuration
                 // but a lot of users don't know how to change it.
                 // This can be forced only by using a global `var` statement.

--- a/lacommunaute/templates/pages/home.html
+++ b/lacommunaute/templates/pages/home.html
@@ -64,10 +64,10 @@
                                 {% for topic in topics_public %}
                                     <li class="mb-3 position-relative">
                                         <a href="{% url 'forum_conversation:topic' topic.forum.slug topic.forum.pk topic.slug topic.pk %}"
-                                            class="matomo-event btn-link stretched-link"
-                                            data-matomo-category="engagement"
-                                            data-matomo-action="view"
-                                            data-matomo-option="topic">
+                                           class="matomo-event btn-link stretched-link"
+                                           data-matomo-category="engagement"
+                                           data-matomo-action="view"
+                                           data-matomo-option="topic">
                                             {{ topic.subject }}
                                         </a>
                                     </li>
@@ -89,10 +89,10 @@
                                 {% for forum in forums_category %}
                                     <li class="mb-3 position-relative">
                                         <a href="{% url 'forum_extension:forum' forum.slug forum.pk %}"
-                                            class="matomo-event btn-link stretched-link"
-                                            data-matomo-category="engagement"
-                                            data-matomo-action="view"
-                                            data-matomo-option="forum">
+                                           class="matomo-event btn-link stretched-link"
+                                           data-matomo-category="engagement"
+                                           data-matomo-action="view"
+                                           data-matomo-option="forum">
                                             [{{ forum.parent.name }}] {{ forum.name }}
                                         </a>
                                     </li>
@@ -114,10 +114,10 @@
                                 {% for topic in topics_newsfeed %}
                                     <li class="mb-3 position-relative">
                                         <a href="{% url 'forum_conversation:topic' topic.forum.slug topic.forum.pk topic.slug topic.pk %}"
-                                            class="matomo-event btn-link stretched-link"
-                                            data-matomo-category="engagement"
-                                            data-matomo-action="view"
-                                            data-matomo-option="news">
+                                           class="matomo-event btn-link stretched-link"
+                                           data-matomo-category="engagement"
+                                           data-matomo-action="view"
+                                           data-matomo-option="news">
                                             {{ topic.subject }}
                                         </a>
                                     </li>

--- a/lacommunaute/templates/pages/home.html
+++ b/lacommunaute/templates/pages/home.html
@@ -135,7 +135,7 @@
 {% block extra_js %}
     {{ block.super }}
     <script async src="https://tally.so/widgets/embed.js"></script>
-    <script defer>
+    <script defer nonce="{{ request.csp_nonce }}">
         // Any given Tally popup will not be shown more than once every `minDaysBetweenDisplays` days.
         const minDaysBetweenDisplays = 14;
         const delayBeforeShowingPopupInSeconds = 45;

--- a/lacommunaute/templates/pages/statistiques.html
+++ b/lacommunaute/templates/pages/statistiques.html
@@ -88,7 +88,7 @@
 {% block extra_js %}
     {{ block.super }}
     <script src="https://cdn.jsdelivr.net/npm/chart.js@4.0.1"></script>
-    <script>
+    <script nonce="{{ request.csp_nonce }}">
         const ctx_stats = document.getElementById('statChart');
         new Chart(ctx_stats, {
             type: 'line',

--- a/poetry.lock
+++ b/poetry.lock
@@ -575,6 +575,24 @@ rcssmin = "1.1.1"
 rjsmin = "1.2.1"
 
 [[package]]
+name = "django-csp"
+version = "3.7"
+description = "Django Content Security Policy support."
+optional = false
+python-versions = "*"
+files = [
+    {file = "django_csp-3.7-py2.py3-none-any.whl", hash = "sha256:01443a07723f9a479d498bd7bb63571aaa771e690f64bde515db6cdb76e8041a"},
+    {file = "django_csp-3.7.tar.gz", hash = "sha256:01eda02ad3f10261c74131cdc0b5a6a62b7c7ad4fd017fbefb7a14776e0a9727"},
+]
+
+[package.dependencies]
+Django = ">=1.8"
+
+[package.extras]
+jinja2 = ["jinja2 (>=2.9.6)"]
+tests = ["jinja2 (>=2.9.6)", "mock (==1.0.1)", "pep8 (==1.4.6)", "pytest (<4.0)", "pytest-django", "pytest-flakes (==1.0.1)", "pytest-pep8 (==1.0.6)", "six (==1.12.0)"]
+
+[[package]]
 name = "django-debug-toolbar"
 version = "3.8.1"
 description = "A configurable set of panels that display various debug information about the current request/response."
@@ -700,6 +718,20 @@ django-js-asset = "*"
 
 [package.extras]
 tests = ["coverage", "mock-django"]
+
+[[package]]
+name = "django-permissions-policy"
+version = "4.17.0"
+description = "Set the draft security HTTP header Permissions-Policy (previously Feature-Policy) on your Django app."
+optional = false
+python-versions = ">=3.8"
+files = [
+    {file = "django_permissions_policy-4.17.0-py3-none-any.whl", hash = "sha256:e317143f8c8ef7ff30dc20bc1343f8f299c9e4423148957d9f0fc2bae04b0ebe"},
+    {file = "django_permissions_policy-4.17.0.tar.gz", hash = "sha256:cb2f0d2772ddab63dabd50331fa823d0cea06c89932d412c8c6aa5fc239b364f"},
+]
+
+[package.dependencies]
+Django = ">=3.2"
 
 [[package]]
 name = "django-social-share"
@@ -2218,4 +2250,4 @@ files = [
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.10"
-content-hash = "1d1db1497245f9d937e48810ced5f701dec4d8ccfbbdeef7b06fa8798c4a4333"
+content-hash = "5904193b894e535d62259a61aa0c3883f4f8a8cde3308c81d7df4aa366bbd241"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,6 +25,8 @@ django-social-share = "^2.3.0"
 django-htmx = "^1.12.2"
 django-taggit = "^3.1.0"
 whoosh = "^2.7.4"
+django-csp = "^3.7"
+django-permissions-policy = "^4.15.0"
 
 
 [tool.poetry.group.dev.dependencies]

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -19,6 +19,9 @@ django-appconf==1.0.5 ; python_version >= "3.10" and python_version < "4.0" \
 django-compressor==4.4 ; python_version >= "3.10" and python_version < "4.0" \
     --hash=sha256:1b0acc9cfba9f69bc38e7c41da9b0d70a20bc95587b643ffef9609cf46064f67 \
     --hash=sha256:6e2b0c0becb9607f5099c2546a824c5b84a6918a34bc37a8a622ffa250313596
+django-csp==3.7 ; python_version >= "3.10" and python_version < "4.0" \
+    --hash=sha256:01443a07723f9a479d498bd7bb63571aaa771e690f64bde515db6cdb76e8041a \
+    --hash=sha256:01eda02ad3f10261c74131cdc0b5a6a62b7c7ad4fd017fbefb7a14776e0a9727
 django-haystack==3.2.1 ; python_version >= "3.10" and python_version < "4.0" \
     --hash=sha256:97e3197aefc225fe405b6f17600a2534bf827cb4d6743130c20bc1a06f7293a4
 django-htmx==1.16.0 ; python_version >= "3.10" and python_version < "4.0" \
@@ -36,6 +39,9 @@ django-machina==1.3.0 ; python_version >= "3.10" and python_version < "4.0" \
 django-mptt==0.14.0 ; python_version >= "3.10" and python_version < "4.0" \
     --hash=sha256:2c92a2b1614c53086278795ccf50580cf1f9b8564f3ff03055dd62bab5987711 \
     --hash=sha256:d9a87433ab0e4f35247c6f6d5a93ace6990860a4ba8796f815d185f773b9acfc
+django-permissions-policy==4.17.0 ; python_version >= "3.10" and python_version < "4.0" \
+    --hash=sha256:cb2f0d2772ddab63dabd50331fa823d0cea06c89932d412c8c6aa5fc239b364f \
+    --hash=sha256:e317143f8c8ef7ff30dc20bc1343f8f299c9e4423148957d9f0fc2bae04b0ebe
 django-social-share==2.3.0 ; python_version >= "3.10" and python_version < "4.0" \
     --hash=sha256:13d0a1fbb2a90e3a6e7eb556315ececd1e93a906574a3284affbe2f43e2f7398 \
     --hash=sha256:37844f3b4f88a2008604ece7eaedd52fd5914f111f13525200ce1101b750757f

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -298,6 +298,9 @@ django-appconf==1.0.5 ; python_version >= "3.10" and python_version < "4.0" \
 django-compressor==4.4 ; python_version >= "3.10" and python_version < "4.0" \
     --hash=sha256:1b0acc9cfba9f69bc38e7c41da9b0d70a20bc95587b643ffef9609cf46064f67 \
     --hash=sha256:6e2b0c0becb9607f5099c2546a824c5b84a6918a34bc37a8a622ffa250313596
+django-csp==3.7 ; python_version >= "3.10" and python_version < "4.0" \
+    --hash=sha256:01443a07723f9a479d498bd7bb63571aaa771e690f64bde515db6cdb76e8041a \
+    --hash=sha256:01eda02ad3f10261c74131cdc0b5a6a62b7c7ad4fd017fbefb7a14776e0a9727
 django-debug-toolbar==3.8.1 ; python_version >= "3.10" and python_version < "4.0" \
     --hash=sha256:24ef1a7d44d25e60d7951e378454c6509bf536dce7e7d9d36e7c387db499bc27 \
     --hash=sha256:879f8a4672d41621c06a4d322dcffa630fc4df056cada6e417ed01db0e5e0478
@@ -321,6 +324,9 @@ django-machina==1.3.0 ; python_version >= "3.10" and python_version < "4.0" \
 django-mptt==0.14.0 ; python_version >= "3.10" and python_version < "4.0" \
     --hash=sha256:2c92a2b1614c53086278795ccf50580cf1f9b8564f3ff03055dd62bab5987711 \
     --hash=sha256:d9a87433ab0e4f35247c6f6d5a93ace6990860a4ba8796f815d185f773b9acfc
+django-permissions-policy==4.17.0 ; python_version >= "3.10" and python_version < "4.0" \
+    --hash=sha256:cb2f0d2772ddab63dabd50331fa823d0cea06c89932d412c8c6aa5fc239b364f \
+    --hash=sha256:e317143f8c8ef7ff30dc20bc1343f8f299c9e4423148957d9f0fc2bae04b0ebe
 django-social-share==2.3.0 ; python_version >= "3.10" and python_version < "4.0" \
     --hash=sha256:13d0a1fbb2a90e3a6e7eb556315ececd1e93a906574a3284affbe2f43e2f7398 \
     --hash=sha256:37844f3b4f88a2008604ece7eaedd52fd5914f111f13525200ce1101b750757f


### PR DESCRIPTION
## Description

🎸 Paramétrage des `Content Security Policies` et `Permission Policies`
🛸 Installation de `django-csp` et de `django-permissions-policy`

🚧 `htmx view` appelée par une `class based view` Django 
surcharge du middleware pour avoir la même valeur de `request.csp_nonce` dans les 2 templates rendus (vérifier l'utilité)

## Type de changement

🚧 technique

## Points d'attention

🦺 suppression de `onclick=DisabledMe` dans l'appel HTMX & correction du placement du script pour masquer le bouton `voir les 99 réponses`
