### PR TITLE
Homepage - call to actions - dynamiser le chargement de la liste des communautes

### DIFF
--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -332,3 +332,7 @@ SIB_ONBOARDING_LIST = 5
 # ---------------------------------------
 TAGGIT_CASE_INSENSITIVE = True
 TAGGIT_STRIP_UNICODE_WHEN_SLUGIFY = True
+
+# SESSIONS
+# ---------------------------------------
+SESSION_COOKIE_SECURE = True

--- a/lacommunaute/forum/tests/tests_views.py
+++ b/lacommunaute/forum/tests/tests_views.py
@@ -545,6 +545,26 @@ class IndexViewTest(TestCase):
         self.assertEqual(response.status_code, 200)
         self.assertContains(response, 'hx-trigger="load"')
 
+    def test_store_upper_visible_forums(self):
+        self.client.force_login(self.user)
+        response = self.client.get(self.url)
+        self.assertEqual(response.status_code, 200)
+        self.assertNotContains(
+            response,
+            '<a class="dropdown-header matomo-event" href="'
+            + reverse("forum_extension:forum", kwargs={"pk": self.forum.pk, "slug": self.forum.slug}),
+        )
+
+        assign_perm("can_see_forum", self.user, self.forum)
+        assign_perm("can_read_forum", self.user, self.forum)
+        response = self.client.get(self.url)
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(
+            response,
+            '<a class="dropdown-header matomo-event" href="'
+            + reverse("forum_extension:forum", kwargs={"pk": self.forum.pk, "slug": self.forum.slug}),
+        )
+
 
 class CreateForumView(TestCase):
     def setUp(self):

--- a/lacommunaute/forum/views.py
+++ b/lacommunaute/forum/views.py
@@ -15,6 +15,7 @@ from lacommunaute.forum.models import Forum
 from lacommunaute.forum_conversation.forms import PostForm
 from lacommunaute.forum_conversation.models import Topic
 from lacommunaute.users.models import User
+from lacommunaute.utils.middleware import store_upper_visible_forums
 
 
 logger = logging.getLogger(__name__)
@@ -32,12 +33,14 @@ class IndexView(BaseIndexView):
 
     def get_queryset(self):
         """Returns the list of items for this view."""
-        return ForumVisibilityContentTree.from_forums(
+        forum_visibility_content_tree = ForumVisibilityContentTree.from_forums(
             self.request.forum_permission_handler.forum_list_filter(
                 Forum.objects.all().prefetch_related("members_group__user_set"),
                 self.request.user,
             ),
         )
+        store_upper_visible_forums(self.request, forum_visibility_content_tree.top_nodes)
+        return forum_visibility_content_tree
 
     def get_context_data(self, **kwargs):
         context = super().get_context_data(**kwargs)

--- a/lacommunaute/inclusion_connect/views.py
+++ b/lacommunaute/inclusion_connect/views.py
@@ -12,7 +12,6 @@ from django.utils.http import urlencode
 
 from lacommunaute.inclusion_connect import constants
 from lacommunaute.inclusion_connect.models import InclusionConnectState, OIDConnectUserData
-from lacommunaute.utils.middleware import store_upper_visible_forums
 
 
 logger = logging.getLogger(__name__)
@@ -145,7 +144,6 @@ def inclusion_connect_callback(request):  # pylint: disable=too-many-return-stat
         return HttpResponseRedirect(next_url)
 
     login(request, user)
-    store_upper_visible_forums(request)
 
     next_url = ic_session["next_url"] or reverse("forum_extension:home")
     return HttpResponseRedirect(next_url)

--- a/lacommunaute/templates/partials/ask_a_question.html
+++ b/lacommunaute/templates/partials/ask_a_question.html
@@ -9,7 +9,7 @@
                     <li>
                         {% for forum in request.session.upper_visible_forums %}
                             <li>
-                                <a href="{{ forum.url }}topic/create/"
+                                <a href="{% url 'forum_conversation:topic_create' forum.slug forum.pk %}"
                                     class="dropdown-item matomo-event"
                                     data-matomo-category="engagement"
                                     data-matomo-action="contribute"

--- a/lacommunaute/templates/partials/header_nav_secondary_items.html
+++ b/lacommunaute/templates/partials/header_nav_secondary_items.html
@@ -16,8 +16,7 @@
                 <ul class="list-unstyled">
                     {% for forum in request.session.upper_visible_forums %}
                         <li>
-                            <a href="{{ forum.url }}"
-                                class="dropdown-header matomo-event"
+                            <a class="dropdown-header matomo-event" href="{% url 'forum_extension:forum' forum.slug forum.pk %}"
                                 data-matomo-category="engagement"
                                 data-matomo-action="view"
                                 data-matomo-option="forum">


### PR DESCRIPTION
## Description

🎸 Dynamiser le chargement des `forum` visibles dans `request.session[UPPER_VISIBLE_FORUMS]` en les mettant à jour avec la liste des `forum` collectés dans `IndexView`
🎸 Supprimer le chargement de `request.session[UPPER_VISIBLE_FORUMS]` lors de l'authentification `inclusion_connect` car inutile


## Type de changement

🪲 Correction de bug (changement non cassant qui corrige un problème).
🚧 technique

### Points d'attention

🦺 `VisibleForumsMiddleware.process_request` n'est utile que lors d'un accès direct à `TopicView` (par exemple), sans naviguer via `IndexView`
🦺 `request.session[UPPER_VISIBLE_FORUMS]` est exploité dans les templates `header_nav_secondary_items` et dans `ask_a_question`
