### PR TITLE
Liste des Questions/Réponses avec filtres sur la page d'accueil

### DIFF
--- a/lacommunaute/forum/tests/tests_views.py
+++ b/lacommunaute/forum/tests/tests_views.py
@@ -286,19 +286,6 @@ class ForumViewTest(TestCase):
         with self.assertNumQueries(31):
             self.client.get(self.url)
 
-    def test_param_new_in_request(self):
-        topic_with_2_posts = TopicFactory(with_post=True, forum=self.forum)
-        topic_is_locked = TopicFactory(with_post=True, forum=self.forum, status=Topic.TOPIC_LOCKED)
-        PostFactory(topic=topic_with_2_posts)
-        self.client.force_login(self.user)
-
-        response = self.client.get(self.url + "?new=1")
-
-        self.assertEqual(response.status_code, 200)
-        self.assertIn(self.topic, response.context_data["topics"])
-        self.assertNotIn(topic_with_2_posts, response.context_data["topics"])
-        self.assertNotIn(topic_is_locked, response.context_data["topics"])
-
     def test_certified_post_display(self):
         topic_certified_post_url = reverse(
             "forum_conversation_extension:showmore_certified",

--- a/lacommunaute/forum/urls.py
+++ b/lacommunaute/forum/urls.py
@@ -1,13 +1,12 @@
 from django.urls import path
 
-from lacommunaute.forum.views import ForumCreateView, ForumView, IndexView, ModeratorEngagementView
+from lacommunaute.forum.views import ForumCreateView, ForumView, ModeratorEngagementView
 
 
 app_name = "forum_extension"
 
 
 urlpatterns = [
-    path("", IndexView.as_view(), name="home"),
     path("forum/create/", ForumCreateView.as_view(), name="create"),
     path("forum/<str:slug>-<int:pk>/", ForumView.as_view(), name="forum"),
     path("forum/<str:slug>-<int:pk>/engagement", ModeratorEngagementView.as_view(), name="engagement"),

--- a/lacommunaute/forum/views.py
+++ b/lacommunaute/forum/views.py
@@ -66,9 +66,6 @@ class ForumView(BaseForumView):
         forum = self.get_forum()
         qs = forum.topics.optimized_for_topics_list(self.request.user.id)
 
-        if self.request.GET.get("new", None):
-            qs = qs.filter(posts_count=1).exclude(status=Topic.TOPIC_LOCKED)
-
         return qs
 
     def get_context_data(self, **kwargs):

--- a/lacommunaute/forum_conversation/enums.py
+++ b/lacommunaute/forum_conversation/enums.py
@@ -1,0 +1,7 @@
+from django.db import models
+
+
+class Filters(models.TextChoices):
+    ALL = "ALL", "Les plus récentes"
+    NEW = "NEW", "En attente de réponse"
+    CERTIFIED = "CERTIFIED", "Réponse certifiée"

--- a/lacommunaute/forum_conversation/tests/tests_views.py
+++ b/lacommunaute/forum_conversation/tests/tests_views.py
@@ -694,3 +694,48 @@ class TopicListViewTest(TestCase):
         response = self.client.get(self.url, **{"HTTP_HX_REQUEST": "true"})
         self.assertTemplateUsed(response, "forum_conversation/topic_list.html")
 
+
+class NewsFeedTopicListViewTest(TestCase):
+    @classmethod
+    def setUpTestData(cls):
+        cls.topic = TopicFactory(with_post=True, type=Topic.TOPIC_NEWS)
+        cls.user = cls.topic.poster
+        cls.forum = cls.topic.forum
+        assign_perm("can_read_forum", cls.topic.poster, cls.topic.forum)
+        cls.url = reverse("forum_conversation_extension:newsfeed_topics_list")
+
+    def test_view(self):
+        TopicFactory(with_post=True, poster=self.user, forum=self.forum)
+        self.client.force_login(self.user)
+
+        response = self.client.get(self.url)
+
+        self.assertEqual(response.status_code, 200)
+        self.assertTemplateUsed(response, "forum_conversation/topic_list.html")
+        self.assertIsInstance(response.context_data["form"], PostForm)
+        self.assertEqual(response.context_data["loadmoretopic_url"], self.url)
+        self.assertEqual(response.context_data["loadmoretopic_suffix"], "newsfeed")
+        self.assertEqual(list(response.context_data["topics"]), [self.topic])
+        self.assertEqual(response.context_data["display_filter_dropdown"], False)
+        self.assertNotContains(response, '<div class="dropdown-menu" id="filterTopicsDropdown" style="">')
+
+    def test_forum_is_private(self):
+        self.forum.is_private = True
+        self.forum.save()
+        response = self.client.get(self.url)
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(len(response.context_data["topics"]), 0)
+
+    def test_pagination(self):
+        TopicFactory.create_batch(9, with_post=True, type=Topic.TOPIC_NEWS)
+        response = self.client.get(self.url)
+
+        self.assertEqual(response.status_code, 200)
+        self.assertNotContains(response, self.url + "?page=2")
+
+        TopicFactory(with_post=True, type=Topic.TOPIC_NEWS)
+        response = self.client.get(self.url)
+
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(response, self.url + "?page=2")

--- a/lacommunaute/forum_conversation/tests/tests_views.py
+++ b/lacommunaute/forum_conversation/tests/tests_views.py
@@ -512,12 +512,26 @@ class TopicViewTest(TestCase):
         response = self.client.get(self.url)
         self.assertEqual(response.status_code, 200)
         self.assertNotContains(response, tag)
+        self.assertContains(
+            response, reverse("forum_extension:forum", kwargs={"pk": self.forum.pk, "slug": self.forum.slug})
+        )
+        self.assertContains(
+            response,
+            f'<span class="badge badge-xs badge-pill badge-info-lighter text-info">{self.forum.name}</span></a>',
+        )
 
         self.topic.tags.add(tag)
 
         response = self.client.get(self.url)
         self.assertEqual(response.status_code, 200)
         self.assertContains(response, tag)
+        self.assertContains(
+            response, reverse("forum_extension:forum", kwargs={"pk": self.forum.pk, "slug": self.forum.slug})
+        )
+        self.assertContains(
+            response,
+            f'<span class="badge badge-xs badge-pill badge-info-lighter text-info">{self.forum.name}</span></a>',
+        )
 
     def test_edit_link_is_visible(self):
         self.client.force_login(self.poster)

--- a/lacommunaute/forum_conversation/tests/tests_views_htmx.py
+++ b/lacommunaute/forum_conversation/tests/tests_views_htmx.py
@@ -226,49 +226,6 @@ class TopicContentViewTest(TestCase):
         self.assertEqual(1, ForumReadTrack.objects.count())
 
 
-class NewsFeedTopicListViewTest(TestCase):
-    @classmethod
-    def setUpTestData(cls):
-        cls.topic = TopicFactory(with_post=True, type=Topic.TOPIC_NEWS)
-        cls.user = cls.topic.poster
-        cls.forum = cls.topic.forum
-        assign_perm("can_read_forum", cls.topic.poster, cls.topic.forum)
-        cls.url = reverse("forum_conversation_extension:newsfeed_topics_list")
-
-    def test_view(self):
-        TopicFactory(with_post=True, poster=self.user, forum=self.forum)
-        self.client.force_login(self.user)
-
-        response = self.client.get(self.url)
-
-        self.assertEqual(response.status_code, 200)
-        self.assertTemplateUsed(response, "forum_conversation/topic_list.html")
-        self.assertEqual(response.context_data["loadmoretopic_url"], self.url)
-        self.assertEqual(response.context_data["loadmoretopic_suffix"], "newsfeed")
-        self.assertEqual(list(response.context_data["topics"]), [self.topic])
-
-    def test_forum_is_private(self):
-        self.forum.is_private = True
-        self.forum.save()
-        response = self.client.get(self.url)
-
-        self.assertEqual(response.status_code, 200)
-        self.assertEqual(len(response.context_data["topics"]), 0)
-
-    def test_pagination(self):
-        TopicFactory.create_batch(9, with_post=True, type=Topic.TOPIC_NEWS)
-        response = self.client.get(self.url)
-
-        self.assertEqual(response.status_code, 200)
-        self.assertNotContains(response, self.url + "?page=2")
-
-        TopicFactory(with_post=True, type=Topic.TOPIC_NEWS)
-        response = self.client.get(self.url)
-
-        self.assertEqual(response.status_code, 200)
-        self.assertContains(response, self.url + "?page=2")
-
-
 class TopicCertifiedPostViewTest(TestCase):
     def test_get_topic_certified_post(self):
         topic = TopicFactory(with_certified_post=True)

--- a/lacommunaute/forum_conversation/tests/tests_views_htmx.py
+++ b/lacommunaute/forum_conversation/tests/tests_views_htmx.py
@@ -7,7 +7,6 @@ from machina.core.db.models import get_model
 from machina.core.loading import get_class
 from taggit.models import Tag
 
-from lacommunaute.forum.factories import ForumFactory
 from lacommunaute.forum_conversation.factories import PostFactory, TopicFactory
 from lacommunaute.forum_conversation.forms import PostForm
 from lacommunaute.forum_conversation.models import Topic
@@ -225,62 +224,6 @@ class TopicContentViewTest(TestCase):
         self.assertEqual(response.status_code, 200)
         self.assertContains(response, post.content)
         self.assertEqual(1, ForumReadTrack.objects.count())
-
-
-class TopicCertifiedListViewTest(TestCase):
-    @classmethod
-    def setUpTestData(cls):
-        cls.url = reverse("forum_conversation_extension:public_certified_topics_list")
-
-    def test_get_view(self):
-        response = self.client.get(self.url)
-
-        self.assertEqual(response.status_code, 200)
-        self.assertTemplateUsed(response, "forum_conversation/topic_list.html")
-        self.assertEqual(response.context_data["loadmoretopic_url"], self.url)
-        self.assertEqual(response.context_data["loadmoretopic_suffix"], "certified")
-
-    def test_get_topic_certified_list(self):
-        certified_private_topic = TopicFactory(with_certified_post=True, forum=ForumFactory(is_private=True))
-        certified_public_topic = TopicFactory(with_certified_post=True)
-        topic = TopicFactory(with_post=True)
-
-        response = self.client.get(self.url)
-        self.assertEqual(response.status_code, 200)
-
-        self.assertContains(response, certified_public_topic.first_post.subject)
-        self.assertContains(response, str(certified_public_topic.first_post.content)[:100])
-        self.assertContains(response, str(certified_public_topic.certified_post.post.content)[:100])
-
-        self.assertNotContains(response, certified_private_topic.first_post.subject)
-        self.assertNotContains(response, str(certified_private_topic.first_post.content)[:100])
-        self.assertNotContains(response, str(certified_private_topic.certified_post.post.content)[:100])
-
-        self.assertNotContains(response, topic.first_post.subject)
-        self.assertNotContains(response, str(topic.first_post.content)[:100])
-
-    def test_pagination(self):
-        TopicFactory.create_batch(10, with_certified_post=True)
-
-        response = self.client.get(self.url)
-        self.assertEqual(response.status_code, 200)
-
-        self.assertNotContains(response, self.url + "?page=2")
-
-        TopicFactory.create_batch(11, with_certified_post=True)
-        response = self.client.get(self.url)
-        self.assertEqual(response.status_code, 200)
-
-        self.assertContains(response, self.url + "?page=2")
-
-    def test_likes(self):
-        topic = TopicFactory(with_certified_post=True, with_like=True)
-        self.client.force_login(topic.poster)
-
-        response = self.client.get(self.url)
-        self.assertEqual(response.status_code, 200)
-
-        self.assertContains(response, '<i class="ri-heart-3-fill" aria-hidden="true"></i><span class="ml-1">1</span')
 
 
 class NewsFeedTopicListViewTest(TestCase):

--- a/lacommunaute/forum_conversation/tests/tests_views_htmx.py
+++ b/lacommunaute/forum_conversation/tests/tests_views_htmx.py
@@ -89,7 +89,7 @@ class ForumTopicListViewTest(TestCase):
         assign_perm("can_read_forum", self.user, self.topic.forum)
         self.client.force_login(self.user)
 
-        with self.assertNumQueries(24):
+        with self.assertNumQueries(22):
             self.client.get(self.url)
 
 

--- a/lacommunaute/forum_conversation/urls.py
+++ b/lacommunaute/forum_conversation/urls.py
@@ -1,5 +1,6 @@
 from django.urls import include, path
 
+from lacommunaute.forum_conversation.views import TopicListView
 from lacommunaute.forum_conversation.views_htmx import (
     ForumTopicListView,
     PostFeedCreateView,
@@ -27,6 +28,7 @@ public_topics_urlpatterns = [
 ]
 
 urlpatterns = [
+    path("", TopicListView.as_view(), name="home"),
     path(
         "forum/<str:forum_slug>-<int:forum_pk>/",
         include(conversation_urlpatterns),

--- a/lacommunaute/forum_conversation/urls.py
+++ b/lacommunaute/forum_conversation/urls.py
@@ -4,7 +4,6 @@ from lacommunaute.forum_conversation.views_htmx import (
     ForumTopicListView,
     PostFeedCreateView,
     PostListView,
-    TopicCertifiedListView,
     TopicCertifiedPostView,
     TopicContentView,
     TopicLikeView,
@@ -24,7 +23,6 @@ conversation_urlpatterns = [
 ]
 
 public_topics_urlpatterns = [
-    path("topic/certified/", TopicCertifiedListView.as_view(), name="public_certified_topics_list"),
     path("topic/newsfeed/", TopicNewsListView.as_view(), name="newsfeed_topics_list"),
 ]
 

--- a/lacommunaute/forum_conversation/urls.py
+++ b/lacommunaute/forum_conversation/urls.py
@@ -1,6 +1,6 @@
 from django.urls import include, path
 
-from lacommunaute.forum_conversation.views import TopicListView
+from lacommunaute.forum_conversation.views import TopicListView, TopicNewsListView
 from lacommunaute.forum_conversation.views_htmx import (
     ForumTopicListView,
     PostFeedCreateView,
@@ -8,7 +8,6 @@ from lacommunaute.forum_conversation.views_htmx import (
     TopicCertifiedPostView,
     TopicContentView,
     TopicLikeView,
-    TopicNewsListView,
 )
 
 

--- a/lacommunaute/forum_conversation/views.py
+++ b/lacommunaute/forum_conversation/views.py
@@ -152,3 +152,22 @@ class TopicListView(ListView):
         context["filters"] = Filters.choices
 
         return context
+
+
+class TopicNewsListView(ListView):
+    context_object_name = "topics"
+    paginate_by = settings.FORUM_TOPICS_NUMBER_PER_PAGE
+    template_name = "forum_conversation/topic_list.html"
+
+    def get_queryset(self):
+        return Topic.objects.filter(forum__in=Forum.objects.public(), type=Topic.TOPIC_NEWS).optimized_for_topics_list(
+            self.request.user.id
+        )
+
+    def get_context_data(self, **kwargs):
+        context = super().get_context_data(**kwargs)
+        context["form"] = PostForm(user=self.request.user)
+        context["loadmoretopic_url"] = reverse("forum_conversation_extension:newsfeed_topics_list")
+        context["loadmoretopic_suffix"] = "newsfeed"
+        context["display_filter_dropdown"] = False
+        return context

--- a/lacommunaute/forum_conversation/views.py
+++ b/lacommunaute/forum_conversation/views.py
@@ -1,18 +1,24 @@
 import logging
 
+from django.conf import settings
 from django.contrib import messages
 from django.urls import reverse
+from django.views.generic import ListView
 from machina.apps.forum_conversation import views
 from machina.core.loading import get_class
 
+from lacommunaute.forum.models import Forum
+from lacommunaute.forum_conversation.enums import Filters
 from lacommunaute.forum_conversation.forms import PostForm, TopicForm
 from lacommunaute.forum_conversation.models import Topic
 from lacommunaute.forum_conversation.shortcuts import get_posts_of_a_topic_except_first_one
 from lacommunaute.forum_upvote.shortcuts import can_certify_post
+from lacommunaute.utils.middleware import store_upper_visible_forums
 
 
 logger = logging.getLogger(__name__)
 
+ForumVisibilityContentTree = get_class("forum.visibility", "ForumVisibilityContentTree")
 TrackingHandler = get_class("forum_tracking.handler", "TrackingHandler")
 track_handler = TrackingHandler()
 
@@ -90,3 +96,59 @@ class TopicView(views.TopicView):
 
     def get_queryset(self):
         return get_posts_of_a_topic_except_first_one(self.topic, self.request.user)
+
+
+class TopicListView(ListView):
+    context_object_name = "topics"
+    paginate_by = settings.FORUM_TOPICS_NUMBER_PER_PAGE
+
+    def get_template_names(self):
+        if self.request.META.get("HTTP_HX_REQUEST"):
+            return ["forum_conversation/topic_list.html"]
+        return ["pages/home.html"]
+
+    def get_filter(self):
+        if not hasattr(self, "filter"):
+            self.filter = self.request.GET.get("filter", None)
+        return self.filter
+
+    def get_content_tree(self):
+        if not hasattr(self, "forum_visibility_content_tree"):
+            self.forum_visibility_content_tree = ForumVisibilityContentTree.from_forums(
+                self.request.forum_permission_handler.forum_list_filter(
+                    Forum.objects.exclude(is_newsfeed=True).prefetch_related("members_group__user_set"),
+                    self.request.user,
+                ),
+            )
+            store_upper_visible_forums(self.request, self.forum_visibility_content_tree.top_nodes)
+        return self.forum_visibility_content_tree
+
+    def get_queryset(self):
+        forums = self.get_content_tree().forums
+        qs = Topic.objects.filter(forum__in=forums).optimized_for_topics_list(self.request.user.id)
+
+        if self.get_filter() == Filters.NEW:
+            qs = qs.unanswered()
+        elif self.get_filter() == Filters.CERTIFIED:
+            qs = qs.filter(certified_post__isnull=False)
+
+        return qs
+
+    def get_context_data(self, **kwargs):
+        context = super().get_context_data(**kwargs)
+        context["form"] = PostForm(user=self.request.user)
+        context["loadmoretopic_url"] = reverse("forum_conversation_extension:home")
+
+        if self.get_filter():
+            context["loadmoretopic_url"] += f"?filter={self.get_filter()}"
+
+        context["active_filter_name"] = (
+            getattr(Filters, self.get_filter(), Filters.ALL).label if self.get_filter() else Filters.ALL.label
+        )
+        context["display_filter_dropdown"] = False if self.request.GET.get("page") else True
+
+        context["loadmoretopic_suffix"] = "topics"
+        context["total"] = self.get_queryset().count()
+        context["filters"] = Filters.choices
+
+        return context

--- a/lacommunaute/forum_conversation/views_htmx.py
+++ b/lacommunaute/forum_conversation/views_htmx.py
@@ -11,7 +11,6 @@ from lacommunaute.forum.models import Forum
 from lacommunaute.forum_conversation.forms import PostForm
 from lacommunaute.forum_conversation.models import Topic
 from lacommunaute.forum_conversation.shortcuts import get_posts_of_a_topic_except_first_one
-from lacommunaute.forum_conversation.views import TopicListView
 from lacommunaute.forum_upvote.shortcuts import can_certify_post
 
 
@@ -115,18 +114,6 @@ class TopicContentView(PermissionRequiredMixin, View):
 
     def get_controlled_object(self):
         return self.get_topic().forum
-
-class TopicNewsListView(TopicListView):
-    def get_queryset(self):
-        return Topic.objects.filter(forum__in=Forum.objects.public(), type=Topic.TOPIC_NEWS).optimized_for_topics_list(
-            self.request.user.id
-        )
-
-    def get_context_data(self, **kwargs):
-        context = super().get_context_data(**kwargs)
-        context["loadmoretopic_url"] = reverse("forum_conversation_extension:newsfeed_topics_list")
-        context["loadmoretopic_suffix"] = "newsfeed"
-        return context
 
 
 class TopicCertifiedPostView(TopicContentView):

--- a/lacommunaute/forum_conversation/views_htmx.py
+++ b/lacommunaute/forum_conversation/views_htmx.py
@@ -11,6 +11,7 @@ from lacommunaute.forum.models import Forum
 from lacommunaute.forum_conversation.forms import PostForm
 from lacommunaute.forum_conversation.models import Topic
 from lacommunaute.forum_conversation.shortcuts import get_posts_of_a_topic_except_first_one
+from lacommunaute.forum_conversation.views import TopicListView
 from lacommunaute.forum_upvote.shortcuts import can_certify_post
 
 
@@ -114,14 +115,6 @@ class TopicContentView(PermissionRequiredMixin, View):
 
     def get_controlled_object(self):
         return self.get_topic().forum
-
-
-class TopicListView(ListView):
-    template_name = "forum_conversation/topic_list.html"
-
-    paginate_by = paginate_by = settings.FORUM_TOPICS_NUMBER_PER_PAGE
-    context_object_name = "topics"
-
 
 class TopicNewsListView(TopicListView):
     def get_queryset(self):

--- a/lacommunaute/forum_conversation/views_htmx.py
+++ b/lacommunaute/forum_conversation/views_htmx.py
@@ -123,19 +123,6 @@ class TopicListView(ListView):
     context_object_name = "topics"
 
 
-class TopicCertifiedListView(TopicListView):
-    def get_queryset(self):
-        return Topic.objects.filter(
-            forum__in=Forum.objects.public(), certified_post__isnull=False
-        ).optimized_for_topics_list(self.request.user.id)
-
-    def get_context_data(self, **kwargs):
-        context = super().get_context_data(**kwargs)
-        context["loadmoretopic_url"] = reverse("forum_conversation_extension:public_certified_topics_list")
-        context["loadmoretopic_suffix"] = "certified"
-        return context
-
-
 class TopicNewsListView(TopicListView):
     def get_queryset(self):
         return Topic.objects.filter(forum__in=Forum.objects.public(), type=Topic.TOPIC_NEWS).optimized_for_topics_list(

--- a/lacommunaute/inclusion_connect/tests/tests_views.py
+++ b/lacommunaute/inclusion_connect/tests/tests_views.py
@@ -41,7 +41,7 @@ def mock_oauth_dance(
     previous_url=None,
     next_url=None,
     assert_redirects=True,
-    expected_route="forum_extension:home",
+    expected_route="forum_conversation_extension:home",
     user_info_email=None,
 ):
     respx.get(constants.INCLUSION_CONNECT_ENDPOINT_AUTHORIZE).respond(302)
@@ -175,11 +175,11 @@ class InclusionConnectLoginTest(InclusionConnectBaseTestCase):
         response = self.client.post(reverse("inclusion_connect:logout"))
 
         # Then log in again.
-        response = self.client.get(reverse("forum_extension:home"))
+        response = self.client.get(reverse("forum_conversation_extension:home"))
         self.assertContains(response, reverse("inclusion_connect:authorize"))
 
         response = mock_oauth_dance(self, assert_redirects=False)
-        expected_redirection = reverse("forum_extension:home")
+        expected_redirection = reverse("forum_conversation_extension:home")
         self.assertRedirects(response, expected_redirection)
 
         # Make sure it was a login instead of a new signup.
@@ -196,13 +196,13 @@ class InclusionConnectLogoutTest(InclusionConnectBaseTestCase):
         respx.get(constants.INCLUSION_CONNECT_ENDPOINT_LOGOUT).respond(200)
         logout_url = reverse("inclusion_connect:logout")
         response = self.client.get(logout_url)
-        self.assertRedirects(response, reverse("forum_extension:home"))
+        self.assertRedirects(response, reverse("forum_conversation_extension:home"))
         self.assertFalse(auth.get_user(self.client).is_authenticated)
 
     @respx.mock
     def test_logout_with_redirection(self):
         mock_oauth_dance(self)
-        expected_redirection = reverse("forum_extension:home")
+        expected_redirection = reverse("forum_conversation_extension:home")
         respx.get(constants.INCLUSION_CONNECT_ENDPOINT_LOGOUT).respond(200)
 
         params = {"redirect_url": expected_redirection}

--- a/lacommunaute/inclusion_connect/views.py
+++ b/lacommunaute/inclusion_connect/views.py
@@ -43,12 +43,12 @@ def _redirect_to_login_page_on_error(error_msg, request=None):
     if request:
         messages.error(request, "Une erreur technique est survenue. Merci de recommencer.")
     logger.error(error_msg)
-    return HttpResponseRedirect(reverse("forum_extension:home"))
+    return HttpResponseRedirect(reverse("forum_conversation_extension:home"))
 
 
 def inclusion_connect_authorize(request):
     # Start a new session.
-    previous_url = request.GET.get("previous_url", reverse("forum_extension:home"))
+    previous_url = request.GET.get("previous_url", reverse("forum_conversation_extension:home"))
     next_url = request.GET.get("next_url")
     sign_in = bool(request.GET.get("sign_in", False))
 
@@ -145,14 +145,14 @@ def inclusion_connect_callback(request):  # pylint: disable=too-many-return-stat
 
     login(request, user)
 
-    next_url = ic_session["next_url"] or reverse("forum_extension:home")
+    next_url = ic_session["next_url"] or reverse("forum_conversation_extension:home")
     return HttpResponseRedirect(next_url)
 
 
 def inclusion_connect_logout(request):
     token = request.GET.get("token")
     state = request.GET.get("state")
-    post_logout_redirect_url = request.GET.get("redirect_url", reverse("forum_extension:home"))
+    post_logout_redirect_url = request.GET.get("redirect_url", reverse("forum_conversation_extension:home"))
 
     # Fallback on session data.
     if not token:

--- a/lacommunaute/pages/tests/tests.py
+++ b/lacommunaute/pages/tests/tests.py
@@ -13,7 +13,7 @@ assign_perm = get_class("forum_permission.shortcuts", "assign_perm")
 
 class HomepageTest(TestCase):
     def test_home_page(self):
-        url = reverse("forum_extension:home")
+        url = reverse("forum_conversation_extension:home")
         response = self.client.get(url)
         self.assertEqual(response.status_code, 200)
         self.assertTemplateUsed(response, "pages/home.html")

--- a/lacommunaute/templates/404.html
+++ b/lacommunaute/templates/404.html
@@ -12,7 +12,7 @@
                         <h1 class="h1">Bienvenue sur le site de la Communauté de l'Inclusion.</h1>
                         <p>Le site a fait peau neuve et le lien sur lequel vous avez cliqué n'est plus disponible.</p>
                         <p>L'aide reste accessible à l'adresse <a href="https://documentation.inclusion.beta.gouv.fr/aide/">documentation.inclusion.beta.gouv.fr/aide/</a></p>
-                        <p>La liste des communautés publiques est accessible à l'adresse <a href="{% url 'forum_extension:home' %}">communaute.inclusion.beta.gouv.fr</a></p>
+                        <p>La liste des communautés publiques est accessible à l'adresse <a href="{% url 'forum_conversation_extension:home' %}">communaute.inclusion.beta.gouv.fr</a></p>
                         <p>Pour retrouver l'intégralité des services, vous pouvez consulter le site <a href="https://inclusion.beta.gouv.fr/">inclusion.beta.gouv.fr</a></p>
                     </div>
                 </div>

--- a/lacommunaute/templates/forum_conversation/partials/topic_filter.html
+++ b/lacommunaute/templates/forum_conversation/partials/topic_filter.html
@@ -1,0 +1,38 @@
+{% load str_filters %}
+
+{% if display_filter_dropdown %}
+    <div class="row align-items-center mb-3">
+        <div class="col-12 col-sm">
+
+            <div class="d-flex align-items-center">
+                <div class="flex-grow-1">
+                    <span class="h5 m-0">{{ total }} question{{ total|pluralizefr }} </span>
+                </div>
+                <div>
+                    <span class="btn-link fs-sm">Filter par :</span>
+                    <button type="button" class="btn btn-sm btn-link dropdown-toggle p-0" data-toggle="dropdown" aria-haspopup="true" aria-controls="filterTopicsDropdown" aria-expanded="false">
+                        {{ active_filter_name }}
+                    </button>
+                    <div class="dropdown-menu dropdown-menu-right" id="filterTopicsDropdown">
+                        <ul class="list-unstyled">
+                            {% for filter in filters %}
+                                <li>
+                                    <button id="filtertopics-button"
+                                        hx-target="#topicsarea"
+                                        hx-swap="outerHTML"
+                                        hx-get="{% url 'forum_conversation_extension:home' %}?filter={{ filter.0 }}"
+                                        class="dropdown-item matomo-event"
+                                        data-matomo-category="engagement"
+                                        data-matomo-action="filter"
+                                        data-matomo-option="topics">
+                                        {{ filter.1 }}
+                                    </button>
+                                </li>
+                            {% endfor %}
+                        </ul>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+{% endif %}

--- a/lacommunaute/templates/forum_conversation/partials/topic_tags.html
+++ b/lacommunaute/templates/forum_conversation/partials/topic_tags.html
@@ -1,3 +1,9 @@
+<a class="matomo-event"
+    href="{% url 'forum_extension:forum' topic.forum.slug topic.forum.pk %}"
+    data-matomo-category="engagement"
+    data-matomo-action="view-tags"
+    data-matomo-option="forum">
+    <span class="badge badge-xs badge-pill badge-info-lighter text-info">{{ topic.forum.name }}</span></a>
 {% for tag in tags %}
     <span class="badge badge-xs badge-pill badge-info-lighter text-info">{{ tag }}</span>
 {% endfor %}

--- a/lacommunaute/templates/forum_conversation/topic_detail.html
+++ b/lacommunaute/templates/forum_conversation/topic_detail.html
@@ -24,11 +24,9 @@
                         <div class="h4 mb-0 flex-grow-1">
                             {% if topic.is_locked %}&nbsp;<i class="fas fa-times-circle locked-indicator" aria-label="{% trans 'This topic is locked' %}"></i>{% endif %}
                             {% include "forum_conversation/partials/poster.html" with post=post topic=topic is_topic_head=True actions=True %}
-                            {% if topic.tags.all %}
-                                <div class="mt-1">
-                                    {% include "forum_conversation/partials/topic_tags.html" with tags=topic.tags.all %}
-                                </div>
-                            {% endif %}
+                            <div class="mt-1">
+                                {% include "forum_conversation/partials/topic_tags.html" with tags=topic.tags.all %}
+                            </div>
                         </div>
                         {% block htmx %}
                             {% include "forum_conversation/partials/topic_likes.html" %}

--- a/lacommunaute/templates/forum_conversation/topic_list.html
+++ b/lacommunaute/templates/forum_conversation/topic_list.html
@@ -4,133 +4,135 @@
 {% load forum_tracking_tags %}
 {% load forum_permission_tags %}
 {% load str_filters %}
+{% load url_add_query %}
 
 {% if forum %}
     {% get_permission 'can_download_files' forum request.user as user_can_download_files %}
 {% endif %}
 
-{% if topics or not hide_if_empty %}
+<div id="topicsarea">
+    {% include "forum_conversation/partials/topic_filter.html" %}
 
-    {% if not force_all_unread and unread_topics == None %}{% get_unread_topics topics request.user as unread_topics %}{% endif %}
-    {% for topic in topics %}
-        <div class="row">
-            <div class="col-12">
-                <div id="{{ topic.pk }}" class="card post mb-3">
-                    <div class="card-header mb-1 d-flex flex-column flex-md-row align-items-md-center">
-                        <div class="topic-thumbnail bg-light d-none d-md-block">
-                            {% if topic.poster.forum_profile.avatar %}
-                                <img src="{{ topic.poster.forum_profile.avatar.url }}" alt="{{ topic.poster.forum_profile.user.get_full_name }}" />
-                            {% else %}
-                                <i class="ri-user-line ri-2x" aria-hidden="true"></i>
-                            {% endif %}
-                        </div>
-                        <p class="h4 mb-0 flex-grow-1">
-                            <span class="topic-icon font-weight-normal {% if topic in unread_topics or force_all_unread %}unread{% endif %}">
-                                <i class="{% if topic.is_sticky %}ri-lightbulb-flash-line{% elif topic.is_announce %}ri-information-line{% else %}ri-record-circle-line{% endif %} ri-xl aria-hidden="true""></i>
-                            </span>
-                            <a href="{% url 'forum_conversation:topic' topic.forum.slug topic.forum.pk topic.slug topic.pk %}"
-                                class="matomo-event"
-                                data-matomo-category="engagement"
-                                data-matomo-action="view"
-                                data-matomo-option="topic">
-                                {{ topic.subject }} {% if topic.is_locked %}&nbsp;<i class="fas fa-times-circle locked-indicator" aria-label="{% trans 'This topic is locked' %}"></i>{% endif %}
-                            </a>
-                        </p>
-                        {% block htmx %}
-                            {% include "forum_conversation/partials/topic_likes.html"%}
-                        {% endblock %}
-                    </div>
-                    <div class="card-body pt-0">
-                        <div class="row">
-                            <div class="col-12 post-content-wrapper mb-1">
-                                {%include "forum_conversation/partials/poster.html" with post=topic.first_post topic=topic is_topic_head=True%}
+    {% if topics or not hide_if_empty %}
+
+        {% for topic in topics %}
+            <div class="row">
+                <div class="col-12">
+                    <div id="{{ topic.pk }}" class="card post mb-3">
+                        <div class="card-header mb-1 d-flex flex-column flex-md-row align-items-md-center">
+                            <div class="topic-thumbnail bg-light d-none d-md-block">
+                                {% if topic.poster.forum_profile.avatar %}
+                                    <img src="{{ topic.poster.forum_profile.avatar.url }}" alt="{{ topic.poster.forum_profile.user.get_full_name }}" />
+                                {% else %}
+                                    <i class="ri-user-line ri-2x" aria-hidden="true"></i>
+                                {% endif %}
                             </div>
-                            {% if topic.tags.all %}
+                            <p class="h4 mb-0 flex-grow-1">
+                                <span class="topic-icon font-weight-normal">
+                                    <i class="{% if topic.is_sticky %}ri-lightbulb-flash-line{% elif topic.is_announce %}ri-information-line{% else %}ri-record-circle-line{% endif %} ri-xl aria-hidden="true""></i>
+                                </span>
+                                <a href="{% url 'forum_conversation:topic' topic.forum.slug topic.forum.pk topic.slug topic.pk %}"
+                                    class="matomo-event"
+                                    data-matomo-category="engagement"
+                                    data-matomo-action="view"
+                                    data-matomo-option="topic">
+                                    {{ topic.subject }} {% if topic.is_locked %}&nbsp;<i class="fas fa-times-circle locked-indicator" aria-label="{% trans 'This topic is locked' %}"></i>{% endif %}
+                                </a>
+                            </p>
+                            {% block htmx %}
+                                {% include "forum_conversation/partials/topic_likes.html" %}
+                            {% endblock %}
+                        </div>
+                        <div class="card-body pt-0">
+                            <div class="row">
+                                <div class="col-12 post-content-wrapper mb-1">
+                                    {% include "forum_conversation/partials/poster.html" with post=topic.first_post topic=topic is_topic_head=True %}
+                                </div>
                                 <div class="col-12 post-content mb-3">
                                     {% include "forum_conversation/partials/topic_tags.html" with tags=topic.tags.all %}
                                 </div>
-                            {% endif %}
-                            <div class="col-12 post-content">
-                                <div id="showmoretopicsarea{{topic.pk}}">
-                                    {{ topic.first_post.content.rendered|urlizetrunc_target_blank:30|img_fluid|truncatechars_html:200 }}
-                                    {% if topic.first_post.content.rendered|length > 200 %}
-                                        <a hx-get="{% url 'forum_conversation_extension:showmore_topic' topic.forum.slug topic.forum.pk topic.slug topic.pk %}"
-                                            id="showmoretopic-button{{topic.pk}}"
-                                            hx-target="#showmoretopicsarea{{topic.pk}}"
-                                            hx-swap="outerHTML"
-                                            class="btn btn-link p-0 mh-auto matomo-event"
-                                            data-matomo-category="engagement"
-                                            data-matomo-action="showmore"
-                                            data-matomo-option="topic"
-                                        >
-                                            {% trans "+ show more" %}
-                                        </a>
+                                <div class="col-12 post-content">
+                                    <div id="showmoretopicsarea{{topic.pk}}">
+                                        {{ topic.first_post.content.rendered|urlizetrunc_target_blank:30|img_fluid|truncatechars_html:200 }}
+                                        {% if topic.first_post.content.rendered|length > 200 %}
+                                            <a hx-get="{% url 'forum_conversation_extension:showmore_topic' topic.forum.slug topic.forum.pk topic.slug topic.pk %}"
+                                                id="showmoretopic-button{{topic.pk}}"
+                                                hx-target="#showmoretopicsarea{{topic.pk}}"
+                                                hx-swap="outerHTML"
+                                                class="btn btn-link p-0 mh-auto matomo-event"
+                                                data-matomo-category="engagement"
+                                                data-matomo-action="showmore"
+                                                data-matomo-option="topic"
+                                            >
+                                                {% trans "+ show more" %}
+                                            </a>
+                                        {% endif %}
+                                    </div>
+                                    {% include "forum_conversation/forum_attachments/attachments_images.html" with post=topic.first_post %}
+
+                                    {% if not forum %}
+                                        {% get_permission 'can_download_files' topic.forum request.user as user_can_download_files %}
+                                    {% endif %}
+                                    {% include "forum_conversation/forum_attachments/attachments_detail.html" with post=topic.first_post user_can_download_files=user_can_download_files %}
+
+                                    {% if topic.poll %}
+                                        {% include "forum_conversation/forum_polls/topic_list_poll_detail.html" with poll=topic.poll%}
+                                    {% endif %}
+
+                                    {% if topic.first_post.enable_signature and topic.poster.forum_profile.signature %}
+                                        <div class="post-signature">
+                                            {{ topic.poster.forum_profile.signature.rendered }}
+                                        </div>
                                     {% endif %}
                                 </div>
-                                {% include "forum_conversation/forum_attachments/attachments_images.html" with post=topic.first_post %}
-
-                                {% if not forum %}
-                                    {% get_permission 'can_download_files' topic.forum request.user as user_can_download_files %}
-                                {% endif %}
-                                {% include "forum_conversation/forum_attachments/attachments_detail.html" with post=topic.first_post user_can_download_files=user_can_download_files %}
-
-                                {% if topic.poll %}
-                                    {% include "forum_conversation/forum_polls/topic_list_poll_detail.html" with poll=topic.poll%}
-                                {% endif %}
-
-                                {% if topic.first_post.enable_signature and topic.poster.forum_profile.signature %}
-                                    <div class="post-signature">
-                                        {{ topic.poster.forum_profile.signature.rendered }}
-                                    </div>
-                                {% endif %}
                             </div>
                         </div>
                     </div>
-                </div>
-                <div id="showmorepostsarea{{topic.pk}}">
-                    <div id="postinfeedarea{{topic.pk}}">
-                        {% if topic.is_certified %}
-                            {% include "forum_conversation/partials/post_certified.html" with post=topic.certified_post.post certifier=topic.certified_post.user %}
-                        {% endif %}
-                        {% include "forum_conversation/partials/post_feed_form_collapsable.html" with post_form=form %}
+                    <div id="showmorepostsarea{{topic.pk}}">
+                        <div id="postinfeedarea{{topic.pk}}">
+                            {% if topic.is_certified %}
+                                {% include "forum_conversation/partials/post_certified.html" with post=topic.certified_post.post certifier=topic.certified_post.user %}
+                            {% endif %}
+                            {% include "forum_conversation/partials/post_feed_form_collapsable.html" with post_form=form %}
+                        </div>
                     </div>
                 </div>
             </div>
-        </div>
-        <div class="row align-items-sm-center mb-3">
-            <div class="col-12 col-sm">
-                {% include "forum_conversation/partials/topic_detail_actions.html" with posts_count=topic.posts_count %}
+            <div class="row align-items-sm-center mb-3">
+                <div class="col-12 col-sm">
+                    {% include "forum_conversation/partials/topic_detail_actions.html" with posts_count=topic.posts_count %}
+                </div>
+                <div class="col-12 col-sm-auto">
+                    {% include "forum_conversation/partials/social_share_buttons.html" with topic=topic %}
+                </div>
             </div>
-            <div class="col-12 col-sm-auto">
-                {% include "forum_conversation/partials/social_share_buttons.html" with topic=topic %}
+        {% empty %}
+            <div class="row m-0 p-3">
+                <div class="col-12 pl-0">
+                    {% if empty_message %}
+                        {{ empty_message }}
+                    {% else %}
+                        {% trans "There are no topics in this forum." %}
+                    {% endif %}
+                </div>
             </div>
-        </div>
-    {% empty %}
-        <div class="row m-0 p-3">
-            <div class="col-12 pl-0">
-                {% if empty_message %}
-                    {{ empty_message }}
-                {% else %}
-                    {% trans "There are no topics in this forum." %}
-                {% endif %}
+        {% endfor %}
+        {% if loadmoretopic_url and is_paginated and page_obj.has_next%}
+            <div id="loadmoretopicsarea{{ loadmoretopic_suffix }}" class="row mx-3 mt-md-5 justify-content-center">
+                <div class="col-12 col-md-auto">
+                    <a hx-get="{% url_add_query loadmoretopic_url page=page_obj.next_page_number %}"
+                        id="loadmoretopics-button"
+                        hx-target="#loadmoretopicsarea{{ loadmoretopic_suffix }}"
+                        hx-swap="outerHTML"
+                        class="btn btn-link btn-ico btn-block justify-content-center matomo-event"
+                        data-matomo-category="engagement"
+                        data-matomo-action="loadmore"
+                        data-matomo-option="topic">
+                        <i class="ri-loop-right-line" aria-hidden="true"></i>
+                        <span>{% trans "load more topics" %}</span>
+                    </a>
+                </div>
             </div>
-        </div>
-    {% endfor %}
-    {% if loadmoretopic_url and is_paginated and page_obj.has_next%}
-        <div id="loadmoretopicsarea{{ loadmoretopic_suffix }}" class="row mx-3 mt-md-5 justify-content-center">
-            <div class="col-12 col-md-auto">
-                <a hx-get="{{ loadmoretopic_url }}?page={{ page_obj.next_page_number }}"
-                    id="loadmoretopics-button"
-                    hx-target="#loadmoretopicsarea{{ loadmoretopic_suffix }}"
-                    hx-swap="outerHTML"
-                    class="btn btn-link btn-ico btn-block justify-content-center matomo-event"
-                    data-matomo-category="engagement"
-                    data-matomo-action="loadmore"
-                    data-matomo-option="topic">
-                    <i class="ri-loop-right-line" aria-hidden="true"></i>
-                    <span>{% trans "load more topics" %}</span>
-                </a>
-            </div>
-        </div>
+        {% endif %}
     {% endif %}
-{% endif %}
+</div>

--- a/lacommunaute/templates/pages/home.html
+++ b/lacommunaute/templates/pages/home.html
@@ -103,24 +103,6 @@
                             </a>
                         </li>
                         <li class="nav-item" role="presentation">
-                            <a id="certified-topics-tab"
-                                data-toggle="tab"
-                                href="#certified-topics"
-                                role="tab"
-                                aria-controls="certified-topics"
-                                aria-selected="false"
-                                hx-target="#certifiedtopicsarea"
-                                hx-swap="outerHTML"
-                                hx-get="{% url 'forum_conversation_extension:public_certified_topics_list' %}"
-                                hx-trigger="load"
-                                class="nav-link matomo-event"
-                                data-matomo-category="engagement"
-                                data-matomo-action="loadmore"
-                                data-matomo-option="certified_topic">
-                                Réponses certifiées
-                            </a>
-                        </li>
-                        <li class="nav-item" role="presentation">
                             <a id="newsfeed-topics-tab"
                                 data-toggle="tab"
                                 href="#newsfeed-topics"

--- a/lacommunaute/templates/pages/home.html
+++ b/lacommunaute/templates/pages/home.html
@@ -80,26 +80,16 @@
                 <div class="s-tabs-01__col col-12">
                     <ul class="s-tabs-01__nav nav nav-tabs" role="tablist">
                         <li class="nav-item" role="presentation">
-                            <a class="nav-link{% if forums_tab %} active{% endif %}" id="forums_tab"
+                            <a class="nav-link active" id="topics-tab"
                                 data-toggle="tab"
-                                href="#forums"
+                                href="#topics"
                                 role="tab"
-                                aria-controls="forums"
-                                aria-selected="{% if forums_tab %}true{% else %}false{% endif %}">
-                                Thématiques
-                            </a>
-                        </li>
-                        <li class="nav-item" role="presentation">
-                            <a class="nav-link{% if pending_topics_tab %} active{% endif %}" id="pending-topics-tab"
-                                data-toggle="tab"
-                                href="#pending-topics"
-                                role="tab"
-                                aria-controls="pending-topics"
-                                aria-selected="{% if pending_topics_tab %}true{% else %}false{% endif %}"
+                                aria-controls="topics"
+                                aria-selected="true"
                                 data-matomo-category="engagement"
                                 data-matomo-action="view"
-                                data-matomo-option="pending_topics">
-                                Questions en attente
+                                data-matomo-option="topics">
+                                Questions/Réponses
                             </a>
                         </li>
                         <li class="nav-item" role="presentation">
@@ -126,24 +116,12 @@
                         </li>
                     </ul>
                     <div class="tab-content topiclist">
-                        <div class="tab-pane fade{% if forums_tab %} show active{% endif %}" id="forums"
+                        <div class="tab-pane fade show active" id="topics"
                             role="tabpanel"
-                            aria-labelledby="forums_tab">
-                            {% forum_list forums %}
-                        </div>
-                        <div class="tab-pane fade{% if pending_topics_tab %} show active{% endif %}" id="pending-topics"
-                            role="tabpanel"
-                            aria-labelledby="pending-topics-tab">
-                            {% with topics=topics topic_list_title="Questions en attente" %}
+                            aria-labelledby="topics-tab">
+                            {% with topics=topics %}
                                 {% include "forum_conversation/topic_list.html" %}
                             {% endwith %}
-                        </div>
-                        <div class="tab-pane fade" id="certified-topics"
-                            role="tabpanel"
-                            aria-labelledby="certified-topics-tab">
-                            <div id="certifiedtopicsarea">
-                                chargement en cours...
-                            </div>
                         </div>
                         <div class="tab-pane fade" id="newsfeed-topics"
                             role="tabpanel"
@@ -174,7 +152,6 @@
             </div>
         </section>
     {% endif %}
-
 {% endblock %}
 
 {% block extra_js %}

--- a/lacommunaute/templates/partials/header.html
+++ b/lacommunaute/templates/partials/header.html
@@ -8,10 +8,10 @@
         <div class="s-header__container container">
             <div class="s-header__row row">
                 <div class="s-header__col s-header__col--logo-ministere col col-md-auto d-flex align-items-center pr-0">
-                    <a href="{% url 'forum_extension:home' %}" class="s-header__logo-ministere"><img src="{% static_theme_images 'logo-republique-francaise.svg' %}" alt="Rébublique Française"></a>
+                    <a href="{% url 'forum_conversation_extension:home' %}" class="s-header__logo-ministere"><img src="{% static_theme_images 'logo-republique-francaise.svg' %}" alt="Rébublique Française"></a>
                 </div>
                 <div class="s-header__col s-header__col--logo-service col-auto d-flex align-items-center px-0">
-                    <a href="{% url 'forum_extension:home' %}"><img src="{% static_theme_images 'logo-communaute-inclusion.svg' %}" alt="La communauté de l'inclusion"></a>
+                    <a href="{% url 'forum_conversation_extension:home' %}"><img src="{% static_theme_images 'logo-communaute-inclusion.svg' %}" alt="La communauté de l'inclusion"></a>
                 </div>
                 <div class="s-header__col s-header__col--nav col d-none d-xl-inline-flex d-xl-flex align-items-center justify-content-end">
                     <nav role="navigation" id="nav-primary" aria-label="Navigation principale">

--- a/lacommunaute/templates/partials/header_nav_secondary_items.html
+++ b/lacommunaute/templates/partials/header_nav_secondary_items.html
@@ -2,32 +2,28 @@
 {% load i18n %}
 {% load theme_inclusion %}
 <ul>
-    {% if request.path == '/' and not user.is_authenticated %}
-        <li class="col-12 col-lg-auto">
-            <a href="#community">
-                Accéder aux {% trans "Forums"|lower %}
-            </a>
-        </li>
-    {% else %}
-        {% comment %} TODO : Si user connecté, liste de ses forums et sous-forums {% endcomment %}
-        <li>
-            <a href="" class="dropdown-toggle" data-toggle="dropdown" aria-haspopup="true" aria-controls="communautesDropdown" aria-expanded="false">Accéder aux {% trans "Forums"|lower %}</a>
-            <div class="dropdown-menu" id="communautesDropdown">
-                <ul class="list-unstyled">
-                    {% for forum in request.session.upper_visible_forums %}
-                        <li>
-                            <a class="dropdown-header matomo-event" href="{% url 'forum_extension:forum' forum.slug forum.pk %}"
-                                data-matomo-category="engagement"
-                                data-matomo-action="view"
-                                data-matomo-option="forum">
-                                {{ forum.name }}
-                            </a>
-                        </li>
-                    {% endfor %}
-                </ul>
-            </div>
-        </li>
-    {% endif %}
+    <li class="col-12 col-lg-auto">
+        <a href="{% url 'forum_conversation_extension:home' %}{% if not user.is_authenticated %}#community{% endif %}">
+            Accéder aux dernières questions-réponses
+        </a>
+    </li>
+    <li>
+        <a href="" class="dropdown-toggle" data-toggle="dropdown" aria-haspopup="true" aria-controls="communautesDropdown" aria-expanded="false">Accéder aux {% trans "Forums"|lower %}</a>
+        <div class="dropdown-menu" id="communautesDropdown">
+            <ul class="list-unstyled">
+                {% for forum in request.session.upper_visible_forums %}
+                    <li>
+                        <a class="dropdown-header matomo-event" href="{% url 'forum_extension:forum' forum.slug forum.pk %}"
+                            data-matomo-category="engagement"
+                            data-matomo-action="view"
+                            data-matomo-option="forum">
+                            {{ forum.name }}
+                        </a>
+                    </li>
+                {% endfor %}
+            </ul>
+        </div>
+    </li>
     <li class="col-12 col-lg-auto mt-3 mt-lg-0">
         <a href="{% url 'event:calendar' %}">
             Accéder aux évènements publics

--- a/lacommunaute/utils/templatetags/url_add_query.py
+++ b/lacommunaute/utils/templatetags/url_add_query.py
@@ -1,0 +1,27 @@
+from urllib.parse import urlsplit, urlunsplit
+
+from django import template
+from django.http import QueryDict
+
+
+register = template.Library()
+
+
+@register.simple_tag
+def url_add_query(url, **kwargs):
+    """
+    Append a querystring param to the given url.
+    If the querystring param is already present it will be replaced
+    otherwise it will be appended.
+
+    Usage:
+        {% load url_add_query %}
+        {% url_add_query request.get_full_path page=2 %}
+    """
+    parsed = urlsplit(url)
+    querystring = QueryDict(parsed.query, mutable=True)
+    for item in kwargs:
+        if item in querystring:
+            querystring.pop(item)
+    querystring.update(kwargs)
+    return urlunsplit(parsed._replace(query=querystring.urlencode()))

--- a/lacommunaute/utils/tests.py
+++ b/lacommunaute/utils/tests.py
@@ -167,6 +167,29 @@ class UtilsTemplateTagsTestCase(TestCase):
         out = template.render(Context({"html": '<img src="image.png">'}))
         self.assertEqual(out, '<img class="img-fluid" src="image.png">')
 
+    def test_url_add_query(self):
+        base_url = faker.url()
+        # Full URL.
+        context = {"url": f"{base_url}/?status=new&page=4&page=1"}
+        template = Template("{% load url_add_query %}{% url_add_query url page=2 %}")
+        out = template.render(Context(context))
+        expected = f"{base_url}/?status=new&amp;page=2"
+        assert out == expected
+
+        # Relative URL.
+        context = {"url": "/?status=new&page=1"}
+        template = Template("{% load url_add_query %}{% url_add_query url page=22 %}")
+        out = template.render(Context(context))
+        expected = "/?status=new&amp;page=22"
+        assert out == expected
+
+        # Empty URL.
+        context = {"url": ""}
+        template = Template("{% load url_add_query %}{% url_add_query url page=1 %}")
+        out = template.render(Context(context))
+        expected = "?page=1"
+        assert out == expected
+
 
 class UtilsStatsTest(TestCase):
     def test_get_strftime(self):


### PR DESCRIPTION
## Description

🎸 Simplification de la page d'accueil en réduisant le nombre d'onglets visibles et en valorisant les questions/réponses les plus récentes
🎸 Ajout de filtres dans l'onglet questions/réponses
🎸 Gestion du filtre lors du chargement des sujets suivants dans l'onglet questions/réponses
🎸 Suppression des onglets 'questions en attente' et 'réponses certifiées'

## Type de changement

🥁 Changement de rupture (modification ou caractéristique qui empêcherait une fonctionnalité existante de fonctionner comme prévu)

### Points d'attention

🦺 réutilisation du tag `url_add_query` en provenance des emplois pour concaténer les paramètres dans les `querry` : filter + page
🦺 fusion de `IndexView` et `TopicListView`, gestion du template selon le contexte htmx
🦺 `TopicNewsListView` rendue independante de `TopicListView` pour du code plus léger

### Captures d'écran (optionnel)

Page d'accueil sans filtre

![image](https://github.com/betagouv/itou-communaute-django/assets/11419273/7140159b-3fa0-44fc-8ab5-e236291edac6)

Filtre des questions par état

![image](https://github.com/betagouv/itou-communaute-django/assets/11419273/f7392c94-bf53-4865-a280-d74701b97320)

Pagination tenant compte du filtre actif

![image](https://github.com/betagouv/itou-communaute-django/assets/11419273/dbc9f384-4c70-4148-ba90-fc37ce7ec0c7)

Actualités sans filtre visible

![image](https://github.com/betagouv/itou-communaute-django/assets/11419273/83e65b35-5370-4caf-9f62-fc157b51a6ad)
