### PR TITLE
Bannière pour la redirection vers le support des emplois

### DIFF
--- a/lacommunaute/templates/forum_conversation/topic_create.html
+++ b/lacommunaute/templates/forum_conversation/topic_create.html
@@ -6,6 +6,9 @@
 
 {% block content %}
     <div class="row">
+        <div class="col-12 mb-3 mb-lg-5">
+            {% include "partials/banner.html" %}
+        </div>
         <div class="col-12">
             <h1>{{ forum.name }}</h1>
         </div>
@@ -18,9 +21,6 @@
             <div class="card post-edit">
                 <div class="card-header">
                     <h3 class="m-0 h4 card-title">{% trans "Post a new topic" %}</h3>
-                </div>
-                <div class="card-body">
-                    {% include "partials/banner.html" %}
                 </div>
                 <div class="card-body">
                     {% include "forum_conversation/partials/topic_form.html" %}

--- a/lacommunaute/templates/forum_conversation/topic_create.html
+++ b/lacommunaute/templates/forum_conversation/topic_create.html
@@ -20,6 +20,9 @@
                     <h3 class="m-0 h4 card-title">{% trans "Post a new topic" %}</h3>
                 </div>
                 <div class="card-body">
+                    {% include "partials/banner.html" %}
+                </div>
+                <div class="card-body">
                     {% include "forum_conversation/partials/topic_form.html" %}
                 </div>
             </div>

--- a/lacommunaute/templates/pages/home.html
+++ b/lacommunaute/templates/pages/home.html
@@ -24,10 +24,12 @@
                     <div class="s-page-menu-01__col s-page-menu-01__col--title col-12 col-lg-8 mt-3 mt-lg-5">
                         {% include "partials/ask_a_question.html" %}
                     </div>
+                    <div class="s-page-menu-01__col col-12 mt-3 mt-lg-5">
+                        {% include "partials/banner.html" %}
+                    </div>
                 </div>
             </div>
         </section>
-
     {% else %}
         <section class="s-page-menu-01 s-page-menu-01--communaute">
             <div class="s-page-menu-01__container container">
@@ -36,10 +38,9 @@
                         <h1 class="h1-hero lh-sm font-weight-bold m-0">Entraide, actus et apprentissage<br>pour les professionnels de l'IAE</h1>
                     </div>
                 </div>
-                <div class="s-page-menu-01__row row">
+                <div class="s-page-menu-01__row row align-items-center">
                     <div class="s-page-menu-01__col s-page-menu-01__col--title col-12 col-lg-8 mt-3 mt-lg-5">
                         <h2 class="h1 mb-3 mb-lg-5">Améliorez votre pratique professionnelle :</h2>
-
                         <ul class="lead list-unstyled mb-md-5">
                             <li class="d-flex mb-2">
                                 <i class="text-success ri-checkbox-circle-fill ri-xxl"></i>
@@ -55,15 +56,20 @@
                             </li>
                         </ul>
                         {% include "partials/ask_a_question.html" %}
-                        <div class="s-page-menu-01__col col-12 d-none d-lg-inline-flex col-md-4">
-                            <div>
-                                <img src="{% static 'images/hp-illustration-01.svg' %}" class="img-fluid" loading="lazy" alt="">
-                            </div>
+                    </div>
+                    <div class="s-page-menu-01__col col-12 d-none d-lg-inline-flex col-md-4">
+                        <div>
+                            <img src="{% static 'images/hp-illustration-01.svg' %}" class="img-fluid w-lg-75" loading="lazy" alt="">
                         </div>
                     </div>
                 </div>
-            </section>
-
+                <div class="s-page-menu-01__row row">
+                    <div class="s-page-menu-01__col col-12 mt-3 mt-lg-5">
+                        {% include "partials/banner.html" %}
+                    </div>
+                </div>
+            </div>
+        </section>
     {% endif %}
 
     <div id="community"></div>

--- a/lacommunaute/templates/partials/ask_a_question.html
+++ b/lacommunaute/templates/partials/ask_a_question.html
@@ -1,27 +1,21 @@
-<div class="row">
-    <div class="col-12 col-lg-auto">
-        <div class="dropdown">
-            <button type="button" class="btn btn-primary dropdown-toggle" data-toggle="dropdown" aria-haspopup="true" aria-controls="AskQuestionDropdown" aria-expanded="false">
-                Poser une question
-            </button>
-            <div class="dropdown-menu" id="AskQuestionDropdown">
-                <ul class="list-unstyled">
-                    <li>
-                        {% for forum in request.session.upper_visible_forums %}
-                            <li>
-                                <a href="{% url 'forum_conversation:topic_create' forum.slug forum.pk %}"
-                                    class="dropdown-item matomo-event"
-                                    data-matomo-category="engagement"
-                                    data-matomo-action="contribute"
-                                    data-matomo-option="new_topic">
-                                    {{ forum.name }}
-                                </a>
-                            </li>
-                        {% endfor %}
-                    </ul>
-                </div>
-            </div>
-        </div>
+<div class="dropdown">
+    <button type="button" class="btn btn-primary btn-block w-100 w-lg-auto dropdown-toggle" data-toggle="dropdown" aria-haspopup="true" aria-controls="AskQuestionDropdown" aria-expanded="false">
+        Poser une question
+    </button>
+    <div class="dropdown-menu" id="AskQuestionDropdown">
+        <ul class="list-unstyled">
+            {% for forum in request.session.upper_visible_forums %}
+                <li>
+                    <a href="{% url 'forum_conversation:topic_create' forum.slug forum.pk %}"
+                        class="dropdown-item matomo-event"
+                        data-matomo-category="engagement"
+                        data-matomo-action="contribute"
+                        data-matomo-option="new_topic">
+                        {{ forum.name }}
+                    </a>
+                </li>
+            {% endfor %}
+        </ul>
     </div>
-    {% include "partials/banner.html" %}
 </div>
+

--- a/lacommunaute/templates/partials/ask_a_question.html
+++ b/lacommunaute/templates/partials/ask_a_question.html
@@ -23,4 +23,5 @@
             </div>
         </div>
     </div>
+    {% include "partials/banner.html" %}
 </div>

--- a/lacommunaute/templates/partials/banner.html
+++ b/lacommunaute/templates/partials/banner.html
@@ -1,3 +1,5 @@
-<div class="col-12 col-lg-auto mt-3 alert alert-important">
-    Une difficulté avec le site des emplois ? Une question à propos d'un Pass IAE ? Posez votre question sur la page du <a href="https://documentation.inclusion.beta.gouv.fr/aide/emplois/"><b>support des emplois de l'inclusion</b></a> !
+<div class="alert alert-important m-0">
+    <p class="mb-0">
+        Une difficulté avec le site des emplois ? Une question à propos d'un Pass IAE ? Posez votre question sur la page du <a href="https://documentation.inclusion.beta.gouv.fr/aide/emplois/" class="font-weight-bold" aria-label="Posez votre question sur la page du support des emplois de l'inclusion (lien externe)">support des emplois de l'inclusion</a><i class="ri-external-link-line ml-2 font-weight-bold" aria-hidden="true"></i> !
+    </p>
 </div>

--- a/lacommunaute/templates/partials/banner.html
+++ b/lacommunaute/templates/partials/banner.html
@@ -1,0 +1,3 @@
+<div class="col-12 col-lg-auto mt-3 alert alert-important">
+    Une difficulté avec le site des emplois ? Une question à propos d'un Pass IAE ? Posez votre question sur la page du <a href="https://documentation.inclusion.beta.gouv.fr/aide/emplois/"><b>support des emplois de l'inclusion</b></a> !
+</div>

--- a/lacommunaute/templates/partials/banner.html
+++ b/lacommunaute/templates/partials/banner.html
@@ -1,5 +1,14 @@
 <div class="alert alert-important m-0">
     <p class="mb-0">
-        Une difficulté avec le site des emplois ? Une question à propos d'un Pass IAE ? Posez votre question sur la page du <a href="https://documentation.inclusion.beta.gouv.fr/aide/emplois/" class="font-weight-bold" aria-label="Posez votre question sur la page du support des emplois de l'inclusion (lien externe)">support des emplois de l'inclusion</a><i class="ri-external-link-line ml-2 font-weight-bold" aria-hidden="true"></i> !
+        Une difficulté avec le site des emplois ? Une question à propos d'un Pass IAE ? Posez votre question sur la page du
+        <a href="https://documentation.inclusion.beta.gouv.fr/aide/emplois/"
+            class="font-weight-bold matomo-event"
+            data-matomo-category="support"
+            data-matomo-action="site_emplois"
+            data-matomo-option="banner"
+            aria-label="Posez votre question sur la page du support des emplois de l'inclusion (lien externe)">
+            support des emplois de l'inclusion
+        </a>
+        <i class="ri-external-link-line ml-2 font-weight-bold" aria-hidden="true"></i> !
     </p>
 </div>

--- a/lacommunaute/templates/partials/footer.html
+++ b/lacommunaute/templates/partials/footer.html
@@ -20,7 +20,19 @@
                 <ul class="s-prefooter__gridlist">
                     <li><a href="{% url 'pages:statistiques' %}">Statistiques</a></li>
                     <li><a href="https://github.com/betagouv/itou-communaute-django" target="_blank" rel="noopener" aria-label="Github (lien externe)">Github</a><i class="ri-external-link-line ml-1 font-weight-bold"></i></li>
-                    <li><a href="https://documentation.inclusion.beta.gouv.fr/aide/emplois/" target="_blank" rel="noopener" aria-label="Posez votre question sur la page du support des emplois de l'inclusion (lien externe)">Support des emplois de l'inclusion</a><i class="ri-external-link-line ml-1 font-weight-bold"></i></li>
+                    <li>
+                        <a href="https://documentation.inclusion.beta.gouv.fr/aide/emplois/"
+                            target="_blank"
+                            rel="noopener"
+                            aria-label="Posez votre question sur la page du support des emplois de l'inclusion (lien externe)"
+                            class="matomo-event"
+                            data-matomo-category="support"
+                            data-matomo-action="site_emplois"
+                            data-matomo-option="footer">
+                            Support des emplois de l'inclusion
+                        </a>
+                        <i class="ri-external-link-line ml-1 font-weight-bold"></i>
+                    </li>
                 </ul>
             </div>
         </div>

--- a/lacommunaute/templates/partials/footer.html
+++ b/lacommunaute/templates/partials/footer.html
@@ -19,7 +19,8 @@
             <div class="s-prefooter__col col-12 col-lg-6 d-flex align-items-center">
                 <ul class="s-prefooter__gridlist">
                     <li><a href="{% url 'pages:statistiques' %}">Statistiques</a></li>
-                    <li><a href="" target="_blank" rel="noopener" aria-label="Github (lien externe)">Github</a><i class="ri-external-link-line ml-1 font-weight-bold"></i></li>
+                    <li><a href="https://github.com/betagouv/itou-communaute-django" target="_blank" rel="noopener" aria-label="Github (lien externe)">Github</a><i class="ri-external-link-line ml-1 font-weight-bold"></i></li>
+                    <li><a href="https://documentation.inclusion.beta.gouv.fr/aide/emplois/" target="_blank" rel="noopener" aria-label="Posez votre question sur la page du support des emplois de l'inclusion (lien externe)">Support des emplois de l'inclusion</a><i class="ri-external-link-line ml-1 font-weight-bold"></i></li>
                 </ul>
             </div>
         </div>


### PR DESCRIPTION
## Description

🎸 Ajout d'une bannière pour rediriger les demandes de support du site des emplois au bon endroit

## Type de changement

🎨 UX

### Captures d'écran (optionnel)

![image](https://github.com/betagouv/itou-communaute-django/assets/11419273/76fdced1-2a68-404d-bd1f-f5d7f7896ee9)

![image](https://github.com/betagouv/itou-communaute-django/assets/11419273/ec8dc7ff-ecc3-4215-ad5b-83143e7b74c0)
