### PR TITLE
[FIX] stats quotidiennes

### DIFF
--- a/lacommunaute/utils/matomo.py
+++ b/lacommunaute/utils/matomo.py
@@ -60,11 +60,13 @@ def get_matomo_visits_data(period, search_date):
     ]
 
 
-def get_matomo_events_data(period, search_date, nb_uniq_visitors_key="nb_uniq_visitors"):
+def get_matomo_events_data(period, search_date, nb_uniq_visitors_key="nb_uniq_visitors", label=None):
     """
     function to extract data from matomo api Events.getCategory call
     """
     datas = get_matomo_data(period=period, search_date=search_date, method="Events.getCategory")
+    if label:
+        datas = list(filter(lambda d: d.get("label") == label, datas))
 
     if not datas:
         return [
@@ -128,7 +130,7 @@ def collect_stats_from_matomo_api(period="day", from_date=date(2022, 12, 5), to_
     while from_date <= to_date:
 
         stats += get_matomo_visits_data(period, from_date)
-        stats += get_matomo_events_data(period, from_date, nb_uniq_visitors_key=keys[period])
+        stats += get_matomo_events_data(period, from_date, nb_uniq_visitors_key=keys[period], label="engagement")
         print(f"Stats collected for {period} {from_date} ({len(stats)} stats collected)")
 
         if period == "day":

--- a/lacommunaute/utils/tests.py
+++ b/lacommunaute/utils/tests.py
@@ -395,6 +395,40 @@ class UtilsGetMatomoEventsDataTest(TestCase):
                 expected_res,
             )
 
+    def test_get_matomo_events_data_with_label(self):
+        label = faker.word()
+        nb_active_visitors = faker.random_int()
+        expected_res = self.uniq_active_visitors_res
+        expected_res[1]["value"] = self.nb_uniq_visitors - nb_active_visitors
+
+        with patch("lacommunaute.utils.matomo.get_matomo_data") as mock_get_matomo_data:
+            mock_get_matomo_data.return_value = [
+                {
+                    "label": label,
+                    "nb_uniq_visitors": self.nb_uniq_visitors,
+                    "subtable": [
+                        {
+                            "label": "view",
+                            "nb_uniq_visitors": nb_active_visitors,
+                        },
+                    ],
+                },
+                {
+                    "label": "not_" + label,
+                    "nb_uniq_visitors": self.nb_uniq_visitors + 1,
+                    "subtable": [
+                        {
+                            "label": "view",
+                            "nb_uniq_visitors": nb_active_visitors + 1,
+                        },
+                    ],
+                },
+            ]
+            self.assertEqual(
+                get_matomo_events_data(period="day", search_date=self.today, label=label),
+                expected_res,
+            )
+
 
 class UtilsMiddlewareStoreUpperVisibleForumTest(TestCase):
     def test_store_upper_visible_forums(self):


### PR DESCRIPTION
## Description

🎸 Filtrer les evenements Matomo sur le `label` `engagement` depuis la mise en place du suivi du lien de support des emplois

## Type de changement

🪲 Correction de bug (changement non cassant qui corrige un problème).
🚧 technique

