### PR TITLE
FIX : ne pas afficher les forums de type catégorie dans la liste des forums visibles

### DIFF
--- a/lacommunaute/forum_conversation/tests/tests_views.py
+++ b/lacommunaute/forum_conversation/tests/tests_views.py
@@ -13,6 +13,7 @@ from machina.core.loading import get_class
 from taggit.models import Tag
 
 from lacommunaute.forum.factories import ForumFactory
+from lacommunaute.forum.models import Forum
 from lacommunaute.forum_conversation.enums import Filters
 from lacommunaute.forum_conversation.factories import PostFactory, TopicFactory
 from lacommunaute.forum_conversation.forms import PostForm
@@ -595,6 +596,9 @@ class TopicListViewTest(TestCase):
         self,
     ):
         hidden_forum = ForumFactory()
+        categ_forum = ForumFactory(type=Forum.FORUM_CAT)
+        assign_perm("can_see_forum", self.user, categ_forum)
+        assign_perm("can_read_forum", self.user, categ_forum)
         self.client.force_login(self.user)
 
         response = self.client.get(self.url)
@@ -604,6 +608,11 @@ class TopicListViewTest(TestCase):
             response,
             '<a class="dropdown-header matomo-event" href="'
             + reverse("forum_extension:forum", kwargs={"pk": hidden_forum.pk, "slug": hidden_forum.slug}),
+        )
+        self.assertNotContains(
+            response,
+            '<a class="dropdown-header matomo-event" href="'
+            + reverse("forum_extension:forum", kwargs={"pk": categ_forum.pk, "slug": categ_forum.slug}),
         )
         self.assertContains(
             response,

--- a/lacommunaute/forum_conversation/views.py
+++ b/lacommunaute/forum_conversation/views.py
@@ -116,7 +116,7 @@ class TopicListView(ListView):
         if not hasattr(self, "forum_visibility_content_tree"):
             self.forum_visibility_content_tree = ForumVisibilityContentTree.from_forums(
                 self.request.forum_permission_handler.forum_list_filter(
-                    Forum.objects.exclude(is_newsfeed=True).prefetch_related("members_group__user_set"),
+                    Forum.objects.exclude(type=Forum.FORUM_CAT).prefetch_related("members_group__user_set"),
                     self.request.user,
                 ),
             )

--- a/lacommunaute/utils/middleware.py
+++ b/lacommunaute/utils/middleware.py
@@ -28,7 +28,7 @@ class VisibleForumsMiddleware(MiddlewareMixin):
         if not forum_visibility_content_tree:
             forum_visibility_content_tree = ForumVisibilityContentTree.from_forums(
                 request.forum_permission_handler.forum_list_filter(
-                    Forum.objects.all(),
+                    Forum.objects.exclude(type=Forum.FORUM_CAT),
                     request.user,
                 ),
             )

--- a/lacommunaute/utils/tests.py
+++ b/lacommunaute/utils/tests.py
@@ -472,12 +472,15 @@ class UtilsMiddlewareVisibleForumsMiddlewareTest(TestCase):
 
         visible_forum = ForumFactory()
         descendant_visible_forum = ForumFactory(parent=visible_forum)
+        categ_forum = ForumFactory(type=Forum.FORUM_CAT)
         ForumFactory()
 
         assign_perm("can_see_forum", user, visible_forum)
         assign_perm("can_read_forum", user, visible_forum)
         assign_perm("can_see_forum", user, descendant_visible_forum)
         assign_perm("can_read_forum", user, descendant_visible_forum)
+        assign_perm("can_see_forum", user, categ_forum)
+        assign_perm("can_read_forum", user, categ_forum)
 
         response = self.client.get("/")
 


### PR DESCRIPTION
## Description

🎸 ne pas afficher les `forum` de type `FORUM_CAT` dans la liste des forums visibles pour éviter le rattachement de `topic` à ce type de `forum`

## Type de changement

🪲 Correction de bug (changement non cassant qui corrige un problème).

