### PR TITLE
Limiter l'affichage des questions non répondues aux thématiques publiques

### DIFF
--- a/lacommunaute/forum_conversation/tests/tests_views.py
+++ b/lacommunaute/forum_conversation/tests/tests_views.py
@@ -296,7 +296,6 @@ class PostCreateViewTest(TestCase):
         )
 
     def test_machina_route_forbidden(self):
-
         self.client.force_login(self.poster)
 
         post_data = {"content": "c"}
@@ -586,7 +585,6 @@ class TopicListViewTest(TestCase):
         self.assertEqual(response.context_data["active_filter_name"], Filters.ALL.label)
 
     def test_has_liked(self):
-
         self.client.force_login(self.user)
         response = self.client.get(self.url)
         # icon: solid heart
@@ -654,6 +652,21 @@ class TopicListViewTest(TestCase):
         for topic in Topic.objects.exclude(id=certified_topic.id):
             with self.subTest(topic):
                 self.assertNotContains(response, topic.subject)
+
+    def test_unanswerd_topics_visibility(self):
+        url = self.url + "?filter=NEW"
+        self.client.force_login(self.user)
+
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(response, self.topic.subject)
+
+        self.forum.is_private = True
+        self.forum.save()
+
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, 200)
+        self.assertNotContains(response, self.topic.subject)
 
     def test_certified_topics_list_content(self):
         certified_private_topic = TopicFactory(with_certified_post=True, forum=ForumFactory(is_private=True))

--- a/lacommunaute/forum_conversation/views.py
+++ b/lacommunaute/forum_conversation/views.py
@@ -128,7 +128,7 @@ class TopicListView(ListView):
         qs = Topic.objects.filter(forum__in=forums).optimized_for_topics_list(self.request.user.id)
 
         if self.get_filter() == Filters.NEW:
-            qs = qs.unanswered()
+            qs = qs.unanswered().filter(forum__in=Forum.objects.public())
         elif self.get_filter() == Filters.CERTIFIED:
             qs = qs.filter(certified_post__isnull=False)
 


### PR DESCRIPTION
## Description

🎸 Ne pas afficher les questions non répondues des thématiques privées

## Type de changement

🎢 Nouvelle fonctionnalité (changement non cassant qui ajoute une fonctionnalité).

### Captures d'écran (optionnel)

![image](https://github.com/betagouv/itou-communaute-django/assets/11419273/ac13ce11-4b53-410a-bf11-71ada7a7821a)
