### PR TITLE
[FIX] date de modification des Forum dans le fichier sitemap

### DIFF
--- a/lacommunaute/pages/sitemaps.py
+++ b/lacommunaute/pages/sitemaps.py
@@ -26,7 +26,7 @@ class ForumSitemap(Sitemap):
         return reverse("forum_extension:forum", kwargs={"pk": obj.pk, "slug": obj.slug})
 
     def lastmod(self, obj: Model) -> str:
-        return obj.last_post_on
+        return obj.updated
 
 
 class TopicSitemap(Sitemap):

--- a/lacommunaute/pages/tests/test_sitemap.py
+++ b/lacommunaute/pages/tests/test_sitemap.py
@@ -15,11 +15,12 @@ def test_sitemap(client, db):
 
 
 def test_topic_is_in_sitemap(client, db):
-    topic = TopicFactory()
+    topic = TopicFactory(with_post=True)
     url = reverse("pages:django.contrib.sitemaps.views.sitemap")
     response = client.get(url)
     assert response.status_code == 200
     assert topic.get_absolute_url() in response.content.decode()
+    assert f"<lastmod>{topic.last_post_on.strftime('%Y-%m-%d')}</lastmod>" in response.content.decode()
 
 
 def test_forum_is_in_sitemap(client, db):
@@ -28,6 +29,7 @@ def test_forum_is_in_sitemap(client, db):
     response = client.get(url)
     assert response.status_code == 200
     assert reverse("forum_extension:forum", kwargs={"pk": forum.pk, "slug": forum.slug}) in response.content.decode()
+    assert f"<lastmod>{forum.updated.strftime('%Y-%m-%d')}</lastmod>" in response.content.decode()
 
 
 def test_flatpage_is_in_sitemap(client, db):


### PR DESCRIPTION
## Description

🎸 Remplacer le `last_post_on` par `update` de l'instance `forum` pour alimenter `<lastmod>` du fichier `sitemap`.
`last_post_on` peut être vide pour les forums de type catégorie, lien ou ceux dont la description sert de fiche technique/FAQ

## Type de changement

🪲 Correction de bug (changement non cassant qui corrige un problème).
🚧 technique

