### PR TITLE
[NOTIFICATION] appel à l'api d'onboarding

### DIFF
--- a/lacommunaute/notification/tasks.py
+++ b/lacommunaute/notification/tasks.py
@@ -26,7 +26,9 @@ def send_notifs_when_first_reply():
 
 
 def add_user_to_list_when_register():
-    bulk_send_user_to_list(collect_new_users_for_onboarding(), settings.SIB_ONBOARDING_LIST)
+    new_users = collect_new_users_for_onboarding()
+    if new_users:
+        bulk_send_user_to_list(new_users, settings.SIB_ONBOARDING_LIST)
 
 
 def send_notifs_on_unanswered_topics(list_id: int) -> None:

--- a/lacommunaute/notification/tasks.py
+++ b/lacommunaute/notification/tasks.py
@@ -8,7 +8,6 @@ from lacommunaute.notification.utils import collect_first_replies, collect_new_u
 
 
 def send_notifs_when_first_reply():
-
     first_replies = collect_first_replies()
 
     for url, subject, to, display_name in first_replies:
@@ -31,7 +30,6 @@ def add_user_to_list_when_register():
 
 
 def send_notifs_on_unanswered_topics(list_id: int) -> None:
-
     contacts = collect_users_from_list(list_id)
 
     if contacts:

--- a/lacommunaute/notification/tests/tests_tasks.py
+++ b/lacommunaute/notification/tests/tests_tasks.py
@@ -90,6 +90,11 @@ class AddUserToListWhenRegister(TestCase):
         self.assertEqual(email_sent_track.response, json.dumps({"message": "OK"}))
         self.assertEqual(email_sent_track.datas, payload)
 
+    def test_no_user_to_add(self):
+        add_user_to_list_when_register()
+
+        self.assertEqual(EmailSentTrack.objects.count(), 0)
+
 
 class SendNotifsOnUnansweredTopics(TestCase):
     def setUp(self):


### PR DESCRIPTION
## Description

🎸 Limiter l'appel à l'API d'onboarding (sendinblue/brevo) uniquement si de nouveaux utilisateurs se sont enregistrés depuis le dernier enregistrement `EmailSentTrack`

## Type de changement

🚧 technique

