### PR TITLE
[FORUM_MEMBER] sécuriser l'accès aux profils

### DIFF
--- a/lacommunaute/forum_member/tests/tests_view.py
+++ b/lacommunaute/forum_member/tests/tests_view.py
@@ -102,6 +102,15 @@ class ModeratorProfileListView(TestCase):
             ),
         )
 
+    def test_queries_number(self):
+        profiles = ForumProfileFactory.create_batch(10)
+        self.forum.members_group.user_set.add(*[profile.user for profile in profiles])
+        self.forum.members_group.save()
+
+        self.client.force_login(self.profile.user)
+        with self.assertNumQueries(19):
+            self.client.get(self.url)
+
 
 class JoinForumLandingView(TestCase):
     def test_token_doesnt_exists(self):

--- a/lacommunaute/forum_member/tests/tests_view.py
+++ b/lacommunaute/forum_member/tests/tests_view.py
@@ -21,7 +21,9 @@ class ForumProfileUpdateViewTest(TestCase):
         view = ForumProfileUpdateView()
         view.request = RequestFactory().get("/")
         view.request.user = forum_profiles.user
-        self.assertEqual(view.get_success_url(), reverse("members:profile", kwargs={"pk": forum_profiles.user.pk}))
+        self.assertEqual(
+            view.get_success_url(), reverse("members:profile", kwargs={"username": forum_profiles.user.username})
+        )
 
 
 class ModeratorProfileListView(TestCase):
@@ -64,7 +66,7 @@ class ModeratorProfileListView(TestCase):
         self.client.force_login(self.profile.user)
         response = self.client.get(self.url)
         self.assertContains(response, forum_profile.user.get_full_name())
-        self.assertContains(response, reverse("members:profile", kwargs={"pk": forum_profile.user_id}))
+        self.assertContains(response, reverse("members:profile", kwargs={"username": forum_profile.user.username}))
 
     def test_ordering_and_count(self):
         self.forum.members_group.user_set.add(ForumProfileFactory(user__first_name="z").user)

--- a/lacommunaute/forum_member/urls.py
+++ b/lacommunaute/forum_member/urls.py
@@ -13,7 +13,7 @@ app_name = "members"
 
 urlpatterns = [
     path("profile/edit/", ForumProfileUpdateView.as_view(), name="profile_update"),
-    path("profile/<str:pk>/", ForumProfileDetailView.as_view(), name="profile"),
+    path("profile/<str:username>/", ForumProfileDetailView.as_view(), name="profile"),
     path("forum/<str:slug>-<int:pk>/", ModeratorProfileListView.as_view(), name="forum_profiles"),
     path("join-forum-landing/<uuid:token>/", JoinForumLandingView.as_view(), name="join_forum_landing"),
     path("join-forum/<uuid:token>/", JoinForumFormView.as_view(), name="join_forum_form"),

--- a/lacommunaute/forum_member/views.py
+++ b/lacommunaute/forum_member/views.py
@@ -24,12 +24,13 @@ PermissionRequiredMixin = get_class("forum_permission.viewmixins", "PermissionRe
 
 
 class ForumProfileDetailView(BaseForumProfileDetailView):
-    pass
+    slug_field = "username"
+    slug_url_kwarg = "username"
 
 
 class ForumProfileUpdateView(BaseForumProfileUpdateView):
     def get_success_url(self):
-        return reverse("members:profile", kwargs={"pk": self.request.user.pk})
+        return reverse("members:profile", kwargs={"username": self.request.user.username})
 
 
 class ModeratorProfileListView(PermissionRequiredMixin, ListView):

--- a/lacommunaute/forum_member/views.py
+++ b/lacommunaute/forum_member/views.py
@@ -50,7 +50,7 @@ class ModeratorProfileListView(PermissionRequiredMixin, ListView):
         """Returns the list of items for this view."""
         self.forum = self.get_forum()
         users = self.forum.members_group.user_set.all()
-        return ForumProfile.objects.filter(user__in=users).order_by("user__first_name")
+        return ForumProfile.objects.filter(user__in=users).select_related("user").order_by("user__first_name")
 
     def get_controlled_object(self):
         """Returns the controlled object."""

--- a/lacommunaute/forum_member/views.py
+++ b/lacommunaute/forum_member/views.py
@@ -63,7 +63,6 @@ class ModeratorProfileListView(PermissionRequiredMixin, ListView):
 
 
 class JoinForumLandingView(TemplateView):
-
     template_name = "forum_member/join_forum_landing.html"
 
     def get_forum(self):
@@ -92,7 +91,6 @@ class JoinForumLandingView(TemplateView):
 
 
 class JoinForumFormView(LoginRequiredMixin, FormView):
-
     template_name = "forum_member/join_forum_form.html"
     form_class = JoinForumForm
 

--- a/lacommunaute/templates/forum_conversation/partials/poster.html
+++ b/lacommunaute/templates/forum_conversation/partials/poster.html
@@ -11,7 +11,7 @@
     {% spaceless %}
         <i class="fas fa-clock"></i>&nbsp;
         {% if post.poster %}
-            {% url 'members:profile' post.poster_id as poster_url %}
+            {% url 'members:profile' post.poster.username as poster_url %}
             {% blocktrans trimmed with poster_url=poster_url poster=post.poster_display_name creation_date=post.created %}
                 By:
                 <a href="{{ poster_url }}"

--- a/lacommunaute/templates/forum_member/moderator_profiles.html
+++ b/lacommunaute/templates/forum_member/moderator_profiles.html
@@ -25,7 +25,7 @@
                             <div class="card">
                                 <div class="card-body">
                                     <h3 class="h5 card-title">
-                                        <a href="{%url 'members:profile' pk=forum_profile.user_id%}"
+                                        <a href="{%url 'members:profile' username=forum_profile.user.username%}"
                                             class="matomo-event"
                                             data-matomo-category="engagement"
                                             data-matomo-action="view"

--- a/lacommunaute/templates/forum_member/profiles.html
+++ b/lacommunaute/templates/forum_member/profiles.html
@@ -26,7 +26,7 @@
                                 {% endif %}
                                 <div class="card-body">
                                     <h3 class="h5 card-title">
-                                        <a href="{%url 'members:profile' pk=forum_profile.user_id%}"
+                                        <a href="{%url 'members:profile' username=forum_profile.user.username%}"
                                             class="matomo-event"
                                             data-matomo-category="engagement"
                                             data-matomo-action="view"

--- a/lacommunaute/templates/partials/header_nav_primary_items.html
+++ b/lacommunaute/templates/partials/header_nav_primary_items.html
@@ -27,7 +27,7 @@
                         <div class="dropdown-divider"></div>
                     </li>
                     <li>
-                        <a href="{% url 'members:profile' user.id %}"
+                        <a href="{% url 'members:profile' user.username %}"
                            class="dropdown-item text-primary matomo-event"
                            data-matomo-category="engagement"
                            data-matomo-action="view"


### PR DESCRIPTION
## Description

🎸 remplacer le `pk` par le `username` dans l'url de `ForumProfileDetailView` pour empecher le scrapping itératif

## Type de changement

🚧 technique

### Points d'attention

🦺 `username` provient d'inclusion connect
🦺 ajout d'un `select_related` sur `ModeratorProfileListView`

### Captures d'écran (optionnel)

Utile pour les changements liés à l'UI.
