### PR TITLE
[NOTIFICATION] filtre sur les questions non répondues

### DIFF
--- a/lacommunaute/notification/tasks.py
+++ b/lacommunaute/notification/tasks.py
@@ -60,7 +60,7 @@ def send_notifs_on_unanswered_topics(list_id: int) -> None:
         count = Topic.objects.unanswered().filter(forum__in=Forum.objects.public()).count()
         link = (
             f"{settings.COMMU_PROTOCOL}://{settings.COMMU_FQDN}/"
-            "?new=1&mtm_campaign=unsanswered&mtm_medium=email#community"
+            "?filter=NEW&mtm_campaign=unsanswered&mtm_medium=email#community"
         )
 
         params = {"count": count, "link": link}

--- a/lacommunaute/notification/tests/tests_tasks.py
+++ b/lacommunaute/notification/tests/tests_tasks.py
@@ -158,7 +158,7 @@ class SendNotifsOnUnansweredTopics(TestCase):
 
         url = (
             f"{settings.COMMU_PROTOCOL}://{settings.COMMU_FQDN}/"
-            "?new=1&mtm_campaign=unsanswered&mtm_medium=email#community"
+            "?filter=NEW&mtm_campaign=unsanswered&mtm_medium=email#community"
         )
 
         params = {"count": 1, "link": url}


### PR DESCRIPTION
## Description

🎸 correction du parametre `filter` dans l'url transmise dans les emails de notifications de questions en attente

## Type de changement

🪲 Correction de bug (changement non cassant qui corrige un problème).

