### PR TITLE
[HOME] tri des dernières questions

### DIFF
--- a/lacommunaute/pages/tests/test_homepage.py
+++ b/lacommunaute/pages/tests/test_homepage.py
@@ -3,7 +3,7 @@ from django.urls import reverse
 
 from lacommunaute.forum.enums import Kind as ForumKind
 from lacommunaute.forum.factories import ForumFactory
-from lacommunaute.forum_conversation.factories import TopicFactory
+from lacommunaute.forum_conversation.factories import PostFactory, TopicFactory
 
 
 def test_context_data(client, db):
@@ -24,3 +24,19 @@ def test_context_data(client, db):
     assert response.context_data["topics_public"].get() == topic
     assert response.context_data["topics_newsfeed"].get() == news
     assert response.context_data["forums_category"].get() == article
+
+
+def test_new_topics_order(client, db):
+    topic1 = TopicFactory(with_post=True, forum=ForumFactory())
+    topic2 = TopicFactory(with_post=True, forum=ForumFactory())
+    url = reverse("pages:home")
+
+    response = client.get(url)
+    assert response.status_code == 200
+    assert list(response.context_data["topics_public"]) == [topic2, topic1]
+
+    PostFactory(topic=topic1)
+
+    response = client.get(url)
+    assert response.status_code == 200
+    assert list(response.context_data["topics_public"]) == [topic2, topic1]

--- a/lacommunaute/pages/views.py
+++ b/lacommunaute/pages/views.py
@@ -57,7 +57,7 @@ class HomeView(TemplateView):
     def get_context_data(self, **kwargs: Any) -> dict[str, Any]:
         context = super().get_context_data(**kwargs)
         context["topics_public"] = Topic.objects.filter(forum__kind=ForumKind.PUBLIC_FORUM, approved=True).order_by(
-            "-last_post_on"
+            "-created"
         )[:4]
         context["topics_newsfeed"] = Topic.objects.filter(forum__kind=ForumKind.NEWS).order_by("-last_post_on")[:4]
         context["forums_category"] = Forum.objects.filter(kind=ForumKind.PUBLIC_FORUM, parent__type=1).order_by(


### PR DESCRIPTION
## Description

🎸 trier les dernières questions par date de création et non plus sur `last_post_on` (date du dernier `Post`)

## Type de changement

🪲 Correction de bug (changement non cassant qui corrige un problème).

