### PR TITLE
[NOTIFICATION] correction de l'url d'accès aux questions non répondues dans l'email de notification

### DIFF
--- a/lacommunaute/notification/tasks.py
+++ b/lacommunaute/notification/tasks.py
@@ -1,4 +1,5 @@
 from django.conf import settings
+from django.urls import reverse
 
 from lacommunaute.forum.models import Forum
 from lacommunaute.forum_conversation.models import Topic
@@ -59,11 +60,12 @@ def send_notifs_on_unanswered_topics(list_id: int) -> None:
     if contacts:
         count = Topic.objects.unanswered().filter(forum__in=Forum.objects.public()).count()
         link = (
-            f"{settings.COMMU_PROTOCOL}://{settings.COMMU_FQDN}/"
-            "?filter=NEW&mtm_campaign=unsanswered&mtm_medium=email#community"
+            f"{settings.COMMU_PROTOCOL}://{settings.COMMU_FQDN}",
+            reverse("forum_conversation_extension:topics"),
+            "?filter=NEW&mtm_campaign=unsanswered&mtm_medium=email#community",
         )
 
-        params = {"count": count, "link": link}
+        params = {"count": count, "link": "".join(link)}
 
         if count > 0:
             send_email(

--- a/lacommunaute/notification/tests/tests_tasks.py
+++ b/lacommunaute/notification/tests/tests_tasks.py
@@ -4,6 +4,7 @@ import httpx
 import respx
 from django.conf import settings
 from django.test import TestCase
+from django.urls import reverse
 from faker import Faker
 
 from config.settings.base import (
@@ -158,11 +159,12 @@ class SendNotifsOnUnansweredTopics(TestCase):
         ]
 
         url = (
-            f"{settings.COMMU_PROTOCOL}://{settings.COMMU_FQDN}/"
-            "?filter=NEW&mtm_campaign=unsanswered&mtm_medium=email#community"
+            f"{settings.COMMU_PROTOCOL}://{settings.COMMU_FQDN}",
+            reverse("forum_conversation_extension:topics"),
+            "?filter=NEW&mtm_campaign=unsanswered&mtm_medium=email#community",
         )
 
-        params = {"count": 1, "link": url}
+        params = {"count": 1, "link": "".join(url)}
         payload = {
             "sender": {"name": "La Communauté", "email": DEFAULT_FROM_EMAIL},
             "to": to,


### PR DESCRIPTION
## Description

🎸 cf titre

## Type de changement

🪲 Correction de bug (changement non cassant qui corrige un problème).

### Points d'attention

🦺 suite de la #347 