### PR TITLE
[NOTIFICATION] informer les parties prenantes des nouvelles réponses

### DIFF
--- a/lacommunaute/forum_conversation/factories.py
+++ b/lacommunaute/forum_conversation/factories.py
@@ -22,6 +22,11 @@ class PostFactory(BasePostFactory):
             UpVote.objects.create(voter=user, content_object=self)
 
 
+class AnonymousPostFactory(PostFactory):
+    username = factory.Faker("email")
+    poster = None
+
+
 class CertifiedPostFactory(factory.django.DjangoModelFactory):
     class Meta:
         model = CertifiedPost

--- a/lacommunaute/forum_conversation/models.py
+++ b/lacommunaute/forum_conversation/models.py
@@ -49,6 +49,17 @@ class TopicQuerySet(models.QuerySet):
             .order_by("-last_post_on")
         )
 
+    def with_first_reply(self, previous_notification_at=None):
+        """
+        The first reply is the second approved post of a topic
+        """
+        first_reply_posts_count = 2
+
+        qs = self.filter(posts_count=first_reply_posts_count)
+        if previous_notification_at:
+            qs = qs.filter(updated__gte=previous_notification_at)
+        return qs
+
 
 class Topic(AbstractTopic):
     likers = models.ManyToManyField(

--- a/lacommunaute/forum_conversation/models.py
+++ b/lacommunaute/forum_conversation/models.py
@@ -59,8 +59,8 @@ class Topic(AbstractTopic):
 
     tags = TaggableManager()
 
-    def get_absolute_url(self):
-        return reverse(
+    def get_absolute_url(self, with_fqdn=False):
+        absolute_url = reverse(
             "forum_conversation:topic",
             kwargs={
                 "forum_pk": self.forum.pk,
@@ -69,6 +69,12 @@ class Topic(AbstractTopic):
                 "slug": self.slug,
             },
         )
+
+        # for tasks context, when we don't have access to request
+        if with_fqdn:
+            return f"{settings.COMMU_PROTOCOL}://{settings.COMMU_FQDN}{absolute_url}"
+
+        return absolute_url
 
     @property
     def poster_email(self):

--- a/lacommunaute/forum_conversation/tests/tests_models.py
+++ b/lacommunaute/forum_conversation/tests/tests_models.py
@@ -120,6 +120,49 @@ class TopicManagerTest(TestCase):
         self.assertEqual(Topic.objects.with_first_reply().count(), 2)
         self.assertEqual(Topic.objects.with_first_reply(previous_notification_at=topic2.updated).get(), topic2)
 
+    def test_with_following_replies(self):
+        topic = TopicFactory(with_post=True)
+        self.assertEqual(Topic.objects.with_following_replies().count(), 0)
+
+        # first reply
+        PostFactory(topic=topic)
+        self.assertEqual(Topic.objects.with_following_replies().count(), 0)
+
+        # following replies
+        posts = PostFactory.create_batch(3, topic=topic)
+        self.assertEqual(Topic.objects.with_following_replies().get().new_replies, 4)
+
+        for i in range(3):
+            with self.subTest(i=i):
+                self.assertEqual(
+                    Topic.objects.with_following_replies(previous_notification_at=posts[i].created).get().new_replies,
+                    3 - i,
+                )
+
+        self.assertEqual(
+            Topic.objects.with_following_replies(
+                previous_notification_at=topic.updated + timedelta(minutes=1)
+            ).count(),
+            0,
+        )
+
+    def test_with_following_replies_on_disapproved_post(self):
+        topic = TopicFactory(with_post=True)
+        first_reply = PostFactory(topic=topic)
+        PostFactory(topic=topic, approved=False)
+        self.assertEqual(Topic.objects.with_following_replies(previous_notification_at=first_reply.created).count(), 0)
+
+    def test_with_following_replies_on_multiple_topics(self):
+        topic1 = TopicFactory(with_post=True)
+        topic2 = TopicFactory(with_post=True)
+
+        PostFactory.create_batch(2, topic=topic1)
+        PostFactory.create_batch(2, topic=topic2)
+
+        self.assertEqual(Topic.objects.with_following_replies().count(), 2)
+        self.assertEqual(Topic.objects.with_following_replies().first(), topic1)
+        self.assertEqual(Topic.objects.with_following_replies().last(), topic2)
+
 
 class TopicModelTest(TestCase):
     @classmethod

--- a/lacommunaute/forum_conversation/tests/tests_models.py
+++ b/lacommunaute/forum_conversation/tests/tests_models.py
@@ -1,3 +1,4 @@
+from django.conf import settings
 from django.core.exceptions import ValidationError
 from django.db import IntegrityError
 from django.test import TestCase
@@ -89,18 +90,21 @@ class TopicModelTest(TestCase):
         cls.topic = TopicFactory(with_post=True)
 
     def test_get_absolute_url(self):
-        topic = TopicFactory()
         self.assertEqual(
-            topic.get_absolute_url(),
+            self.topic.get_absolute_url(),
             reverse(
                 "forum_conversation:topic",
                 kwargs={
-                    "forum_pk": topic.forum.pk,
-                    "forum_slug": topic.forum.slug,
-                    "pk": topic.pk,
-                    "slug": topic.slug,
+                    "forum_pk": self.topic.forum.pk,
+                    "forum_slug": self.topic.forum.slug,
+                    "pk": self.topic.pk,
+                    "slug": self.topic.slug,
                 },
             ),
+        )
+        self.assertEqual(
+            self.topic.get_absolute_url(with_fqdn=True),
+            f"{settings.COMMU_PROTOCOL}://{settings.COMMU_FQDN}{self.topic.get_absolute_url()}",
         )
 
     def test_poster_email(self):

--- a/lacommunaute/forum_conversation/tests/tests_models.py
+++ b/lacommunaute/forum_conversation/tests/tests_models.py
@@ -84,6 +84,10 @@ class TopicManagerTest(TestCase):
 
 
 class TopicModelTest(TestCase):
+    @classmethod
+    def setUpTestData(cls):
+        cls.topic = TopicFactory(with_post=True)
+
     def test_get_absolute_url(self):
         topic = TopicFactory()
         self.assertEqual(
@@ -100,23 +104,22 @@ class TopicModelTest(TestCase):
         )
 
     def test_poster_email(self):
-        topic = TopicFactory(with_post=True)
-        self.assertEqual(topic.poster_email, topic.first_post.poster.email)
+        self.assertEqual(self.topic.poster_email, self.topic.first_post.poster.email)
 
-        topic = TopicFactory()
-        post = PostFactory(topic=topic, username="user@beta.gouv.fr")
-        self.assertEqual(topic.poster_email, post.username)
+        anonymous_topic = TopicFactory()
+        anonymous_post = AnonymousPostFactory(topic=anonymous_topic)
+        self.assertEqual(anonymous_topic.poster_email, anonymous_post.username)
 
     def test_poster_display_name(self):
-        topic = TopicFactory(with_post=True)
-        self.assertEqual(topic.first_post.poster_display_name, get_forum_member_display_name(topic.first_post.poster))
+        self.assertEqual(
+            self.topic.first_post.poster_display_name, get_forum_member_display_name(self.topic.first_post.poster)
+        )
 
-        post = PostFactory(topic=topic, username="user@beta.gouv.fr")
+        post = PostFactory(topic=self.topic, username="user@beta.gouv.fr")
         self.assertEqual(post.poster_display_name, "user")
 
     def test_is_certified(self):
-        topic = TopicFactory(with_post=True)
-        self.assertFalse(topic.is_certified)
+        self.assertFalse(self.topic.is_certified)
 
         topic = TopicFactory(with_certified_post=True)
         self.assertTrue(topic.is_certified)

--- a/lacommunaute/notification/emails.py
+++ b/lacommunaute/notification/emails.py
@@ -10,7 +10,7 @@ from lacommunaute.notification.models import EmailSentTrack
 logger = logging.getLogger(__name__)
 
 
-def send_email(to, params, template_id, kind):
+def send_email(to, params, template_id, kind, bcc=None):
     headers = {"api-key": settings.SIB_API_KEY, "Content-Type": "application/json", "Accept": "application/json"}
     payload = {
         "sender": {"name": "La Communauté", "email": settings.DEFAULT_FROM_EMAIL},
@@ -18,6 +18,8 @@ def send_email(to, params, template_id, kind):
         "params": params,
         "templateId": template_id,
     }
+    if bcc:
+        payload["bcc"] = bcc
 
     response = httpx.post(settings.SIB_SMTP_URL, headers=headers, json=payload)
 

--- a/lacommunaute/notification/tasks.py
+++ b/lacommunaute/notification/tasks.py
@@ -1,6 +1,7 @@
 from django.conf import settings
 from django.urls import reverse
 
+from config.settings.base import DEFAULT_FROM_EMAIL
 from lacommunaute.forum.models import Forum
 from lacommunaute.forum_conversation.models import Topic
 from lacommunaute.notification.emails import bulk_send_user_to_list, collect_users_from_list, send_email
@@ -15,36 +16,38 @@ from lacommunaute.notification.utils import (
 def send_notifs_when_first_reply():
     first_replies = collect_first_replies()
 
-    for url, subject, to, display_name in first_replies:
-        contacts = [{"email": to}]
+    for url, subject, emails, display_name in first_replies:
+        contacts = [{"email": email} for email in emails]
         params = {
             "url": f"{url}?mtm_campaign=firstreply&mtm_medium=email",
             "topic_subject": subject,
             "display_name": display_name,
         }
         send_email(
-            to=contacts,
+            to=[{"email": DEFAULT_FROM_EMAIL}],
             params=params,
             template_id=settings.SIB_FIRST_REPLY_TEMPLATE,
             kind=EmailSentTrackKind.FIRST_REPLY,
+            bcc=contacts,
         )
 
 
 def send_notifs_on_following_replies():
     replies = collect_following_replies()
 
-    for url, subject, to, count_txt in replies:
-        contacts = [{"email": to}]
+    for url, subject, emails, count_txt in replies:
+        contacts = [{"email": email} for email in emails]
         params = {
             "url": f"{url}?mtm_campaign=followingreplies&mtm_medium=email",
             "topic_subject": subject,
             "count_txt": count_txt,
         }
         send_email(
-            to=contacts,
+            to=[{"email": DEFAULT_FROM_EMAIL}],
             params=params,
             template_id=settings.SIB_FOLLOWING_REPLIES_TEMPLATE,
             kind=EmailSentTrackKind.FOLLOWING_REPLIES,
+            bcc=contacts,
         )
 
 

--- a/lacommunaute/notification/tests/tests_emails.py
+++ b/lacommunaute/notification/tests/tests_emails.py
@@ -31,24 +31,22 @@ class SendEmailTestCase(TestCase):
 
     @respx.mock
     def test_send_email(self):
-        to = [{"email": faker.email()}]
-        params = faker.text()
-        template_id = faker.random_int()
-        kind = "first_reply"
+        send_email(self.to, self.params, self.template_id, self.kind)
 
-        payload = {
-            "sender": {"name": "La Communauté", "email": DEFAULT_FROM_EMAIL},
-            "to": to,
-            "params": params,
-            "templateId": template_id,
-        }
-
-        send_email(to, params, template_id, kind)
-
-        self.assertEqual(EmailSentTrack.objects.count(), 1)
-        email_sent_track = EmailSentTrack.objects.first()
+        email_sent_track = EmailSentTrack.objects.get()
         self.assertEqual(email_sent_track.status_code, 200)
         self.assertEqual(email_sent_track.response, json.dumps({"message": "OK"}))
+        self.assertEqual(email_sent_track.datas, self.payload)
+        self.assertEqual(email_sent_track.kind, self.kind)
+
+    @respx.mock
+    def test_send_email_with_bcc(self):
+        self.payload["bcc"] = [{"email": faker.email()}]
+
+        send_email(self.to, self.params, self.template_id, self.kind, self.payload["bcc"])
+
+        email_sent_track = EmailSentTrack.objects.get()
+        self.assertEqual(email_sent_track.datas, self.payload)
 
 
 class BulkSendUserToListTestCase(TestCase):

--- a/lacommunaute/notification/tests/tests_tasks.py
+++ b/lacommunaute/notification/tests/tests_tasks.py
@@ -50,9 +50,13 @@ class SendNotifsWhenFirstReplyTestCase(TestCase):
             "display_name": post.poster_display_name,
         }
         payload = {
-            "sender": {"name": "La Communauté", "email": DEFAULT_FROM_EMAIL},
-            "to": [{"email": topic.poster_email}],
+            "to": [{"email": DEFAULT_FROM_EMAIL}],
+            "bcc": [
+                {"email": email}
+                for email in sorted(topic.posts.exclude(id=topic.last_post_id).values_list("poster__email", flat=True))
+            ],
             "params": params,
+            "sender": {"name": "La Communauté", "email": DEFAULT_FROM_EMAIL},
             "templateId": 2,
         }
 
@@ -80,9 +84,13 @@ class SendNotifsOnFollowingReplyTestCase(TestCase):
 
         params = {"url": url, "topic_subject": topic.subject, "count_txt": "2 nouvelles réponses"}
         payload = {
-            "sender": {"name": "La Communauté", "email": DEFAULT_FROM_EMAIL},
-            "to": [{"email": topic.poster_email}],
+            "to": [{"email": DEFAULT_FROM_EMAIL}],
+            "bcc": [
+                {"email": email}
+                for email in sorted(topic.posts.exclude(id=topic.last_post_id).values_list("poster__email", flat=True))
+            ],
             "params": params,
+            "sender": {"name": "La Communauté", "email": DEFAULT_FROM_EMAIL},
             "templateId": 13,
         }
 

--- a/lacommunaute/notification/utils.py
+++ b/lacommunaute/notification/utils.py
@@ -1,4 +1,4 @@
-from django.conf import settings
+from datetime import datetime
 from django.db.models import Count, F, Q
 from django.utils.timezone import now, timedelta
 
@@ -8,7 +8,7 @@ from lacommunaute.notification.models import BouncedEmail, EmailSentTrack
 from lacommunaute.users.models import User
 
 
-def last_notification(kind=None):
+def last_notification(kind=None) -> datetime:
     return getattr(EmailSentTrack.objects.filter(kind=kind).last(), "created", now() - timedelta(days=5))
 
 


### PR DESCRIPTION
## Description

🎸 Notifier toutes les parties prenantes d'un `Topic` lors des nouveaux messages.
🎸 Les parties prenantes sont les `posters` anonymes et authentifiés, les `likers` et les `upvoters`.
🎸 Le `poster` du dernier `post` du `topic` n'est pas notifiés.
🎸 Deux types de notifications :
1. notification de la première réponse, envoyée dans l'heure
2. notification des réponses suivantes, envoyées quotidiennement

## Type de changement

🎢 Evolution de la fonctionnalité (changement non cassant).

### Points d'attention

🦺 L'objet `EmailSentTrack` permet d'enregistrer la date du dernier traitement de notification. Ne sont considérés que les `Topic` mis à jour après. 

🦺 notifications de premiere reponse (tache cron hourly)
* méthode `lacommunaute.notification.utils.collect_first_replies`
* `EmailSentTrack`, kind : `EmailSentTrackKind.FIRST_REPLY` 

🦺 notifications de reponse suivante (tache cron daily)
* méthode `lacommunaute.notification.utils.collect_following_replies`
* `EmailSentTrack`, kind : `EmailSentTrackKind.FOLLOWING_REPLIES`
