### PR TITLE
[TOPICS] filtrer les sujets à partir des étiquettes - part 1

### DIFF
--- a/lacommunaute/forum_conversation/factories.py
+++ b/lacommunaute/forum_conversation/factories.py
@@ -62,3 +62,12 @@ class TopicFactory(BaseTopicFactory):
             return
         PostFactory(topic=self, poster=self.poster)
         CertifiedPostFactory(topic=self, post=PostFactory(topic=self, poster=self.poster), user=self.poster)
+
+    @factory.post_generation
+    def with_tags(self, create, extracted, **kwargs):
+        if not create or not extracted:
+            return
+
+        if isinstance(extracted, list):
+            for tag in extracted:
+                self.tags.add(tag)

--- a/lacommunaute/forum_conversation/tests/tests_views.py
+++ b/lacommunaute/forum_conversation/tests/tests_views.py
@@ -575,6 +575,15 @@ class TopicListViewTest(TestCase):
             with self.subTest(topic):
                 self.assertNotContains(response, topic.subject)
 
+    def test_queryset_filtered_on_tag(self):
+        tag = faker.word()
+        tagged_topic = TopicFactory(with_post=True, forum=self.forum, with_tags=[tag])
+
+        response = self.client.get(self.url + f"?tags={tag}")
+        self.assertEqual(response.context_data["total"], 1)
+        self.assertContains(response, tagged_topic.subject, status_code=200)
+        self.assertNotContains(response, self.topic.subject)
+
     def test_pagination(self):
         self.client.force_login(self.user)
         TopicFactory.create_batch(9, with_post=True, forum=self.forum)

--- a/lacommunaute/forum_conversation/tests/tests_views.py
+++ b/lacommunaute/forum_conversation/tests/tests_views.py
@@ -610,13 +610,12 @@ class TopicListViewTest(TestCase):
         for param in params:
             with self.subTest(param=param):
                 encoded_params = urlencode({k: v for k, v in param.items() if v})
-                response = self.client.get(self.url + f"?{encoded_params}")
-                if encoded_params:
-                    self.assertContains(
-                        response, self.url + f"?{encoded_params.replace('&','&amp;')}&amp;page=2", status_code=200
-                    )
-                else:
-                    self.assertContains(response, self.url + "?page=2", status_code=200)
+                url_with_params = self.url + f"?{encoded_params}" if encoded_params else self.url
+                expected_url = (
+                    url_with_params.replace("&", "&amp;") + "&amp;page=2" if encoded_params else self.url + "?page=2"
+                )
+                response = self.client.get(url_with_params)
+                self.assertContains(response, expected_url, status_code=200)
 
     def test_filter_dropdown_visibility(self):
         response = self.client.get(self.url)

--- a/lacommunaute/forum_conversation/views.py
+++ b/lacommunaute/forum_conversation/views.py
@@ -116,6 +116,11 @@ class TopicListView(ListView):
             self.filter = self.request.GET.get("filter", None)
         return self.filter
 
+    def get_tags(self):
+        if not hasattr(self, "tags"):
+            self.tags = self.request.GET.get("tags", None)
+        return self.tags
+
     def get_queryset(self):
         qs = Topic.objects.filter(forum__kind=ForumKind.PUBLIC_FORUM).optimized_for_topics_list(self.request.user.id)
 
@@ -123,6 +128,9 @@ class TopicListView(ListView):
             qs = qs.unanswered()
         elif self.get_filter() == Filters.CERTIFIED:
             qs = qs.filter(certified_post__isnull=False)
+
+        if self.get_tags():
+            qs = qs.filter(tags__slug__in=self.get_tags().split(","))
 
         return qs
 

--- a/lacommunaute/forum_conversation/views.py
+++ b/lacommunaute/forum_conversation/views.py
@@ -1,4 +1,5 @@
 import logging
+from urllib.parse import urlencode
 
 from django.conf import settings
 from django.contrib import messages
@@ -137,10 +138,13 @@ class TopicListView(ListView):
     def get_context_data(self, **kwargs):
         context = super().get_context_data(**kwargs)
         context["form"] = PostForm(user=self.request.user)
-        context["loadmoretopic_url"] = reverse("forum_conversation_extension:topics")
 
-        if self.get_filter():
-            context["loadmoretopic_url"] += f"?filter={self.get_filter()}"
+        encoded_params = urlencode(
+            {k: v for k, v in {"filter": self.get_filter(), "tags": self.get_tags()}.items() if v}
+        )
+        context["loadmoretopic_url"] = reverse("forum_conversation_extension:topics")
+        if encoded_params:
+            context["loadmoretopic_url"] += f"?{encoded_params}"
 
         context["active_filter_name"] = (
             getattr(Filters, self.get_filter(), Filters.ALL).label if self.get_filter() else Filters.ALL.label


### PR DESCRIPTION
## Description

🎸 Permettre le filtre des `topics` sur les `tags` dans `TopicListView`
🎸 Gérer les combinaisons de filtrage 'tags' x 'filter'

## Type de changement

🎢 Nouvelle fonctionnalité (changement non cassant qui ajoute une fonctionnalité).
🚧 technique

### Points d'attention

🦺 l'UI sera adaptée dans la PR - partie 2


### Captures d'écran (optionnel)

![image](https://github.com/betagouv/itou-communaute-django/assets/11419273/47fd1f9d-7faa-4feb-96bf-3d2b68d0aa7b)
