### PR TITLE
[SEO] ajout de balises nofollow

### DIFF
--- a/lacommunaute/forum/tests/tests_views.py
+++ b/lacommunaute/forum/tests/tests_views.py
@@ -354,6 +354,7 @@ class ForumViewTest(TestCase):
         anonymous_html = (
             '<a href="/inclusion_connect/authorize?next_url=%2Fforum%2F'
             f'{child_forum.slug}-{child_forum.pk}%2F%23{child_forum.pk}"'
+            ' rel="nofollow"'
             ' class="btn btn-sm btn-ico-only btn-link btn-secondary" data-toggle="tooltip" data-placement="top"'
             ' title="Connectez-vous pour sauvegarder">'
             '\n                <i class="ri-bookmark-line" aria-hidden="true"></i><span class="ml-1">0</span>'

--- a/lacommunaute/templates/event/event_calendar.html
+++ b/lacommunaute/templates/event/event_calendar.html
@@ -37,7 +37,7 @@
                             {% trans "Post a new Public Event" %}
                         </a>
                     {% else %}
-                        <a href="{% inclusion_connect_url next_url %}" class="btn btn-primary" data-toggle="tooltip" data-placement="top" title="Connectez-vous pour contribuer">
+                        <a href="{% inclusion_connect_url next_url %}" rel="nofollow" class="btn btn-primary" data-toggle="tooltip" data-placement="top" title="Connectez-vous pour contribuer">
                             {% trans "Post a new Public Event" %}
                         </a>
                     {% endif %}

--- a/lacommunaute/templates/forum/forum_detail.html
+++ b/lacommunaute/templates/forum/forum_detail.html
@@ -97,6 +97,7 @@
                         <div class="col-12 col-sm-auto forum-actions-block">
                             {% if user_can_add_topic %}
                                 <a href="{% url 'forum_conversation:topic_create' forum.slug forum.pk %}"
+                                   rel="nofollow"
                                    class="btn btn-primary btn-ico matomo-event"
                                    data-matomo-category="engagement"
                                    data-matomo-action="contribute"

--- a/lacommunaute/templates/forum_conversation/partials/topic_likes.html
+++ b/lacommunaute/templates/forum_conversation/partials/topic_likes.html
@@ -17,7 +17,7 @@
 
             </button>
         {% else %}
-            <a href="{% inclusion_connect_url next_url topic.pk %}" class="btn btn-ico btn-link btn-like pr-0 text-nowrap" data-toggle="tooltip" data-placement="top" title="Connectez-vous pour contribuer">
+            <a href="{% inclusion_connect_url next_url topic.pk %}" rel="nofollow" class="btn btn-ico btn-link btn-like pr-0 text-nowrap" data-toggle="tooltip" data-placement="top" title="Connectez-vous pour contribuer">
 
                 <i class="ri-heart-3-line" aria-hidden="true"></i><span class="ml-1">{{counter}}</span>
             </a>

--- a/lacommunaute/templates/forum_member/join_forum_landing.html
+++ b/lacommunaute/templates/forum_member/join_forum_landing.html
@@ -29,7 +29,7 @@
                             <p>Si vous avez déjà utilisé un service à destination des professionnels de l'inclusion, vous avez probablement déjà un compte Inclusion Connect.</p>
                         </div>
                         <div class="card-footer text-right">
-                            <a href="{{ inclusion_connect_url }}" class="btn btn-ico btn-outline-primary stretched-link">
+                            <a href="{{ inclusion_connect_url }}" rel="nofollow" class="btn btn-ico btn-outline-primary stretched-link">
                                 <i class="ri-login-box-line ri-lg"></i>
                                 <span>{% trans "Login" %}</span>
                             </a>
@@ -45,7 +45,7 @@
                             <p>Si vous n'avez pas encore de compte, vous pouvez le créer maintenant et l'utiliser sur tous les services proposant Inclusion Connect.</p>
                         </div>
                         <div class="card-footer text-right">
-                            <a href="{{ inclusion_connect_url }}&sign_in=1" class="btn btn-ico btn-outline-primary stretched-link">
+                            <a href="{{ inclusion_connect_url }}&sign_in=1" rel="nofollow" class="btn btn-ico btn-outline-primary stretched-link">
                                 <i class="ri-login-box-line ri-lg"></i>
                                 <span>{% trans "Sign in" %}</span>
                             </a>

--- a/lacommunaute/templates/partials/ask_a_question.html
+++ b/lacommunaute/templates/partials/ask_a_question.html
@@ -4,6 +4,7 @@
     <div class="row align-items-center">
         <div class="col-12 col-md-auto">
             <a href="{% url 'forum_conversation:topic_create' forum.slug forum.pk %}"
+               rel="nofollow"
                class="btn btn-primary btn-ico btn-block matomo-event"
                data-matomo-category="engagement"
                data-matomo-action="contribute"

--- a/lacommunaute/templates/partials/header_nav_primary_items.html
+++ b/lacommunaute/templates/partials/header_nav_primary_items.html
@@ -90,7 +90,7 @@
         </li>
     {% else %}
         <li>
-            <a href="{% url 'inclusion_connect:authorize' %}" class="btn btn-inclusion-connect">
+            <a href="{% url 'inclusion_connect:authorize' %}" rel="nofollow" class="btn btn-inclusion-connect">
                 <img src="{% static_theme_images 'logo-inclusion-connect-two-lines.svg' %}" alt="Se connecter | S'inscrire" height="37">
             </a>
         </li>

--- a/lacommunaute/templates/partials/upvotes.html
+++ b/lacommunaute/templates/partials/upvotes.html
@@ -21,7 +21,7 @@
                 </button>
             </form>
         {% else %}
-            <a href="{% inclusion_connect_url next_url obj.id %}" class="btn btn-sm btn-ico-only btn-link btn-secondary" data-toggle="tooltip" data-placement="top" title="Connectez-vous pour sauvegarder">
+            <a href="{% inclusion_connect_url next_url obj.id %}" rel="nofollow" class="btn btn-sm btn-ico-only btn-link btn-secondary" data-toggle="tooltip" data-placement="top" title="Connectez-vous pour sauvegarder">
                 <i class="{% if obj.has_upvoted %}ri-bookmark-fill{% else %}ri-bookmark-line{% endif %}" aria-hidden="true"></i><span class="ml-1">{{counter}}</span>
             </a>
         {% endif %}


### PR DESCRIPTION
## Description

🎸 AJouter la balise `rel=nofollow` sur les pages à faible valeur ajoutée :
- liens d'authentification via IC
- liens "poser une question"
- lien "répondre"

## Type de changement

🚧 technique

### Points d'attention

🦺 SEO