### PR TITLE
[SEARCH] fix - le fichier d'index est absent lors de certains tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -49,4 +49,4 @@ exports
 .vscode/launch.json
 
 # Whoosh index
-whoosh_index/
+whoosh_index*

--- a/lacommunaute/forum_search/tests/test_search_indexes.py
+++ b/lacommunaute/forum_search/tests/test_search_indexes.py
@@ -1,11 +1,19 @@
 import urllib.parse
 
 import pytest
+from django.conf import settings
 from django.core.management import call_command
 from django.urls import reverse
 
 from lacommunaute.forum.factories import ForumFactory
 from lacommunaute.forum_conversation.factories import TopicFactory
+
+
+@pytest.fixture(scope="session", autouse=True)
+def haystack_woosh_path_xdist_suffix_fixture(worker_id) -> None:
+    for haystack_setting in settings.HAYSTACK_CONNECTIONS.values():
+        if haystack_setting["ENGINE"] == "haystack.backends.whoosh_backend.WhooshEngine":
+            haystack_setting["PATH"] = "_".join([haystack_setting["PATH"], worker_id])
 
 
 @pytest.fixture(name="search_url")

--- a/lacommunaute/forum_search/tests/test_search_indexes.py
+++ b/lacommunaute/forum_search/tests/test_search_indexes.py
@@ -8,20 +8,20 @@ from lacommunaute.forum.factories import ForumFactory
 from lacommunaute.forum_conversation.factories import TopicFactory
 
 
-@pytest.fixture
-def search_url():
+@pytest.fixture(name="search_url")
+def search_url_fixture():
     return reverse("forum_search_extension:search")
 
 
-@pytest.fixture
-def public_forums():
+@pytest.fixture(name="public_forums")
+def public_forums_fixture():
     forums = ForumFactory.create_batch(2, with_public_perms=True)
     call_command("rebuild_index", noinput=True, interactive=False)
     return forums
 
 
-@pytest.fixture
-def public_topics():
+@pytest.fixture(name="public_topics")
+def public_topics_fixture():
     topics = TopicFactory.create_batch(2, forum=ForumFactory(with_public_perms=True), with_post=True)
     call_command("rebuild_index", noinput=True, interactive=False)
     return topics


### PR DESCRIPTION
## Description

🎸 Résoudre l'erreur aléatoire, lors de l'execution des tests en mode distribué :
```
whoosh.index.EmptyIndexError: Index 'MAIN' does not exist in FileStorage('/path/to/betagouv/itou-communaute-django/whoosh_index')
```

Les tests en mode distribué provoquent parfois la suppression de l'index de recherche "commun". La solution consiste à créer un index par worker. Chaque worker crée et supprime son index indépendamment des autres.

## Type de changement

🪲 Correction de bug (changement non cassant qui corrige un problème).
🚧 technique

### Points d'attention

🦺 la fixture `worker_id` récupère l'id du worker, sinon `master` en mode non distribué
🦺 mise à jour du `.gitignore` ;)


