### PR TITLE
[SEO] dédoublonner les ID

### DIFF
--- a/lacommunaute/forum/tests/tests_views.py
+++ b/lacommunaute/forum/tests/tests_views.py
@@ -342,7 +342,7 @@ class ForumViewTest(TestCase):
         response = self.client.get(url)
         self.assertContains(
             response,
-            'div class="dropdown-menu dropdown-menu-end" aria-labelledby="dropdownMenuSocialShare">',
+            f'div class="dropdown-menu dropdown-menu-end" aria-labelledby="dropdownMenuSocialShare{child_forum.id}">',
             status_code=200,
         )
 

--- a/lacommunaute/templates/forum/forum_detail.html
+++ b/lacommunaute/templates/forum/forum_detail.html
@@ -48,10 +48,10 @@
                     </div>
                     <div class="col-12 col-lg-3">
                         <a href="{% url 'forum_extension:forum' parent_forum.slug parent_forum.id %}"
-                            class="matomo-event h3 text-decoration-none d-inline-block"
-                            data-matomo-category="engagement"
-                            data-matomo-action="view"
-                            data-matomo-option="forum">
+                           class="matomo-event h3 text-decoration-none d-inline-block"
+                           data-matomo-category="engagement"
+                           data-matomo-action="view"
+                           data-matomo-option="forum">
                             Les autres fiches du thème
                         </a>
                         <ul class="nav nav-tabs flex-column">
@@ -97,11 +97,11 @@
                         <div class="col-12 col-sm-auto forum-actions-block">
                             {% if user_can_add_topic %}
                                 <a href="{% url 'forum_conversation:topic_create' forum.slug forum.pk %}"
-                                    rel="nofollow"
-                                    class="btn btn-primary btn-ico matomo-event"
-                                    data-matomo-category="engagement"
-                                    data-matomo-action="contribute"
-                                    data-matomo-option="new_topic">
+                                   rel="nofollow"
+                                   class="btn btn-primary btn-ico matomo-event"
+                                   data-matomo-category="engagement"
+                                   data-matomo-action="contribute"
+                                   data-matomo-option="new_topic">
                                     <i class="ri-chat-new-line ri-lg"></i>
                                     <span>{% if forum.kind == 'NEWS' %}{% trans "New news" %}{% else %}{% trans "New topic" %}{% endif %}</span>
                                 </a>
@@ -112,10 +112,10 @@
                                 </button>
                                 <div class="dropdown-menu" aria-labelledby="id_dropdown_moderators_stats_button">
                                     <a href="{% url 'members:forum_profiles' forum.slug forum.pk %}"
-                                        class="dropdown-item matomo-event"
-                                        data-matomo-category="engagement"
-                                        data-matomo-action="view"
-                                        data-matomo-option="directory">
+                                       class="dropdown-item matomo-event"
+                                       data-matomo-category="engagement"
+                                       data-matomo-action="view"
+                                       data-matomo-option="directory">
                                         {% trans "Members" %}
                                     </a>
                                 </div>
@@ -135,22 +135,22 @@
                         <ul class="s-tabs-01__nav nav nav-tabs" role="tablist">
                             <li class="nav-item" role="presentation">
                                 <a class="nav-link active" id="topics-tab"
-                                    data-bs-toggle="tab"
-                                    href="#topics"
-                                    role="tab"
-                                    aria-controls="topics"
-                                    aria-selected="true">
+                                   data-bs-toggle="tab"
+                                   href="#topics"
+                                   role="tab"
+                                   aria-controls="topics"
+                                   aria-selected="true">
                                     Sujets
                                 </a>
                             </li>
                             {% if announces %}
                                 <li class="nav-item" role="presentation">
                                     <a class="nav-link" id="announces-tab"
-                                        data-bs-toggle="tab"
-                                        href="#announces"
-                                        role="tab"
-                                        aria-controls="announces"
-                                        aria-selected="false">
+                                       data-bs-toggle="tab"
+                                       href="#announces"
+                                       role="tab"
+                                       aria-controls="announces"
+                                       aria-selected="false">
                                         Annonces
                                     </a>
                                 </li>
@@ -163,16 +163,16 @@
                         </ul>
                         <div class="tab-content topiclist">
                             <div class="tab-pane fade show active" id="topics"
-                                role="tabpanel"
-                                aria-labelledby="topics-tab">
+                                 role="tabpanel"
+                                 aria-labelledby="topics-tab">
                                 {% with unread_topics=unread_topics  %}
                                     {% include "forum_conversation/topic_list.html" %} <!-- note vincentporte : to be optimized -->
                                 {% endwith %}
                             </div>
                             {% if announces %}
                                 <div class="tab-pane fade" id="announces"
-                                    role="tabpanel"
-                                    aria-labelledby="announces-tab">
+                                     role="tabpanel"
+                                     aria-labelledby="announces-tab">
                                     {% with topics=announces hide_if_empty=True unread_topics=unread_topics loadmoretopic_url=None %}
                                         {% include "forum_conversation/topic_list.html" %} <!-- note vincentporte : to be optimized -->
                                     {% endwith %}

--- a/lacommunaute/templates/forum/forum_detail.html
+++ b/lacommunaute/templates/forum/forum_detail.html
@@ -41,7 +41,7 @@
                             </div>
                             <div class="col-12 col-sm-auto">
                                 {% include "partials/upvotes.html" with obj=forum kind="forum"%}
-                                {% include "partials/social_share_buttons.html" with text=forum.name instance=forum %}
+                                {% include "partials/social_share_buttons.html" with text=forum.name instance=forum id=forum.pk %}
                             </div>
                         </div>
                         {{forum.description.rendered|urlizetrunc_target_blank:30}}

--- a/lacommunaute/templates/forum_conversation/partials/post_feed_form_collapsable.html
+++ b/lacommunaute/templates/forum_conversation/partials/post_feed_form_collapsable.html
@@ -10,12 +10,12 @@
                 <div class="row">
                     <div class="col-12 post-content-wrapper">
                         <form hx-post="{% url 'forum_conversation_extension:post_create' topic.forum.slug topic.forum.pk topic.slug topic.pk %}"
-                            hx-target="#postinfeedarea{{topic.pk}}"
-                            hx-swap="outerHTML"
-                            class="majorpoints matomo-event"
-                            data-matomo-category="engagement"
-                            data-matomo-action="contribute"
-                            data-matomo-option="post">
+                              hx-target="#postinfeedarea{{topic.pk}}"
+                              hx-swap="outerHTML"
+                              class="majorpoints matomo-event"
+                              data-matomo-category="engagement"
+                              data-matomo-action="contribute"
+                              data-matomo-option="post">
                             {% csrf_token %}
 
                             {% if post_form.non_field_errors %}

--- a/lacommunaute/templates/forum_conversation/partials/post_feed_form_collapsable.html
+++ b/lacommunaute/templates/forum_conversation/partials/post_feed_form_collapsable.html
@@ -25,7 +25,7 @@
                                     </div>
                                 {% endfor %}
                             {% endif %}
-                            {% include "partials/form_field.html" with field=post_form.content %}
+                            {% include "partials/form_field.html" with field=post_form.content id=topic.pk %}
                             {% if post_form.username %}
                                 {% include "partials/form_field.html" with field=post_form.username %}
                             {% endif %}

--- a/lacommunaute/templates/forum_conversation/topic_detail.html
+++ b/lacommunaute/templates/forum_conversation/topic_detail.html
@@ -66,7 +66,7 @@
             {% include "forum_conversation/partials/topic_detail_actions.html" %}
         </div>
         <div class="col-12 col-sm-auto">
-            {% include "partials/social_share_buttons.html" with text=topic.subject instance=topic %}
+            {% include "partials/social_share_buttons.html" with text=topic.subject instance=topic id=topic.pk %}
         </div>
     </div>
     <div class="row mt-5 mb-5">

--- a/lacommunaute/templates/forum_conversation/topic_list.html
+++ b/lacommunaute/templates/forum_conversation/topic_list.html
@@ -32,10 +32,10 @@
                                     <i class="{% if topic.is_sticky %}ri-lightbulb-flash-line{% elif topic.is_announce %}ri-information-line{% else %}ri-record-circle-line{% endif %} ri-xl aria-hidden="true""></i>
                                 </span>
                                 <a href="{% url 'forum_conversation:topic' topic.forum.slug topic.forum.pk topic.slug topic.pk %}"
-                                    class="matomo-event"
-                                    data-matomo-category="engagement"
-                                    data-matomo-action="view"
-                                    data-matomo-option="topic">
+                                   class="matomo-event"
+                                   data-matomo-category="engagement"
+                                   data-matomo-action="view"
+                                   data-matomo-option="topic">
                                     {{ topic.subject }} {% if topic.is_locked %}&nbsp;<i class="fas fa-times-circle locked-indicator" aria-label="{% trans 'This topic is locked' %}"></i>{% endif %}
                                 </a>
                             </p>
@@ -56,13 +56,13 @@
                                         {{ topic.first_post.content.rendered|urlizetrunc_target_blank:30|img_fluid|truncatechars_html:200 }}
                                         {% if topic.first_post.content.rendered|length > 200 %}
                                             <a hx-get="{% url 'forum_conversation_extension:showmore_topic' topic.forum.slug topic.forum.pk topic.slug topic.pk %}"
-                                                id="showmoretopic-button{{topic.pk}}"
-                                                hx-target="#showmoretopicsarea{{topic.pk}}"
-                                                hx-swap="outerHTML"
-                                                class="btn btn-link p-0 mh-auto matomo-event"
-                                                data-matomo-category="engagement"
-                                                data-matomo-action="showmore"
-                                                data-matomo-option="topic"
+                                               id="showmoretopic-button{{topic.pk}}"
+                                               hx-target="#showmoretopicsarea{{topic.pk}}"
+                                               hx-swap="outerHTML"
+                                               class="btn btn-link p-0 mh-auto matomo-event"
+                                               data-matomo-category="engagement"
+                                               data-matomo-action="showmore"
+                                               data-matomo-option="topic"
                                             >
                                                 {% trans "+ show more" %}
                                             </a>
@@ -121,13 +121,13 @@
             <div id="loadmoretopicsarea{{ loadmoretopic_suffix }}" class="row mx-3 mt-md-5 justify-content-center">
                 <div class="col-12 col-md-auto">
                     <a hx-get="{% url_add_query loadmoretopic_url page=page_obj.next_page_number %}"
-                        id="loadmoretopics-button"
-                        hx-target="#loadmoretopicsarea{{ loadmoretopic_suffix }}"
-                        hx-swap="outerHTML"
-                        class="btn btn-link btn-ico btn-block justify-content-center matomo-event"
-                        data-matomo-category="engagement"
-                        data-matomo-action="loadmore"
-                        data-matomo-option="topic">
+                       id="loadmoretopics-button"
+                       hx-target="#loadmoretopicsarea{{ loadmoretopic_suffix }}"
+                       hx-swap="outerHTML"
+                       class="btn btn-link btn-ico btn-block justify-content-center matomo-event"
+                       data-matomo-category="engagement"
+                       data-matomo-action="loadmore"
+                       data-matomo-option="topic">
                         <i class="ri-loop-right-line" aria-hidden="true"></i>
                         <span>{% trans "load more topics" %}</span>
                     </a>

--- a/lacommunaute/templates/forum_conversation/topic_list.html
+++ b/lacommunaute/templates/forum_conversation/topic_list.html
@@ -103,7 +103,7 @@
                     {% include "forum_conversation/partials/topic_detail_actions.html" with posts_count=topic.posts_count %}
                 </div>
                 <div class="col-12 col-sm-auto">
-                    {% include "partials/social_share_buttons.html" with text=topic.subject instance=topic %}
+                    {% include "partials/social_share_buttons.html" with text=topic.subject instance=topic id=topic.pk %}
                 </div>
             </div>
         {% empty %}

--- a/lacommunaute/templates/forum_conversation/topic_list_newsfeed.html
+++ b/lacommunaute/templates/forum_conversation/topic_list_newsfeed.html
@@ -32,7 +32,7 @@
                                 </a>
                             </p>
                             <div>
-                                {% include "partials/social_share_buttons.html" with text=topic.subject instance=topic %}
+                                {% include "partials/social_share_buttons.html" with text=topic.subject instance=topic id=topic.pk %}
                             </div>
                         </div>
                         <div class="card-body pt-0">

--- a/lacommunaute/templates/forum_conversation/topic_list_newsfeed.html
+++ b/lacommunaute/templates/forum_conversation/topic_list_newsfeed.html
@@ -24,10 +24,10 @@
                             </div>
                             <p class="h4 mb-0 flex-grow-1">
                                 <a href="{% url 'forum_conversation:topic' topic.forum.slug topic.forum.pk topic.slug topic.pk %}"
-                                    class="matomo-event"
-                                    data-matomo-category="engagement"
-                                    data-matomo-action="view"
-                                    data-matomo-option="news">
+                                   class="matomo-event"
+                                   data-matomo-category="engagement"
+                                   data-matomo-action="view"
+                                   data-matomo-option="news">
                                     {{ topic.subject }} {% if topic.is_locked %}&nbsp;<i class="fas fa-times-circle locked-indicator" aria-label="{% trans 'This topic is locked' %}"></i>{% endif %}
                                 </a>
                             </p>
@@ -45,13 +45,13 @@
                                         {{ topic.first_post.content.rendered|urlizetrunc_target_blank:30|img_fluid|truncatechars_html:200 }}
                                         {% if topic.first_post.content.rendered|length > 200 %}
                                             <a hx-get="{% url 'forum_conversation_extension:showmore_topic' topic.forum.slug topic.forum.pk topic.slug topic.pk %}"
-                                                id="showmoretopic-button{{topic.pk}}"
-                                                hx-target="#showmoretopicsarea{{topic.pk}}"
-                                                hx-swap="outerHTML"
-                                                class="btn btn-link p-0 mh-auto matomo-event"
-                                                data-matomo-category="engagement"
-                                                data-matomo-action="showmore"
-                                                data-matomo-option="news"
+                                               id="showmoretopic-button{{topic.pk}}"
+                                               hx-target="#showmoretopicsarea{{topic.pk}}"
+                                               hx-swap="outerHTML"
+                                               class="btn btn-link p-0 mh-auto matomo-event"
+                                               data-matomo-category="engagement"
+                                               data-matomo-action="showmore"
+                                               data-matomo-option="news"
                                             >
                                                 {% trans "+ show more" %}
                                             </a>
@@ -84,13 +84,13 @@
             <div id="loadmoretopicsarea{{ loadmoretopic_suffix }}" class="row mx-3 mt-md-5 justify-content-center">
                 <div class="col-12 col-md-auto">
                     <a hx-get="{% url_add_query loadmoretopic_url page=page_obj.next_page_number %}"
-                        id="loadmoretopics-button"
-                        hx-target="#loadmoretopicsarea{{ loadmoretopic_suffix }}"
-                        hx-swap="outerHTML"
-                        class="btn btn-link btn-ico btn-block justify-content-center matomo-event"
-                        data-matomo-category="engagement"
-                        data-matomo-action="loadmore"
-                        data-matomo-option="topic">
+                       id="loadmoretopics-button"
+                       hx-target="#loadmoretopicsarea{{ loadmoretopic_suffix }}"
+                       hx-swap="outerHTML"
+                       class="btn btn-link btn-ico btn-block justify-content-center matomo-event"
+                       data-matomo-category="engagement"
+                       data-matomo-action="loadmore"
+                       data-matomo-option="topic">
                         <i class="ri-loop-right-line" aria-hidden="true"></i>
                         <span>{% trans "load more topics" %}</span>
                     </a>

--- a/lacommunaute/templates/partials/form_field.html
+++ b/lacommunaute/templates/partials/form_field.html
@@ -18,6 +18,10 @@
     {% if field.help_text %}<small class="form-text text-muted">{{ field.help_text }}</small>{% endif %}
     {% for error in field.errors %}<span class="text-danger error">{{ error }}</span>{% endfor %}
     {% if field.auto_id == 'id_content' %}
-        {% include "partials/form_field_mentions.html" %}
+        {% if id %}
+            {% include "partials/form_field_mentions.html" with id=id%}
+        {% else %}
+            {% include "partials/form_field_mentions.html" %}
+        {% endif %}
     {% endif %}
 </div>

--- a/lacommunaute/templates/partials/form_field_mentions.html
+++ b/lacommunaute/templates/partials/form_field_mentions.html
@@ -1,9 +1,9 @@
 <small class="form-text text-muted">
     <a data-bs-toggle="collapse"
-        href="#collapseMentionsHelp"
-        role="button"
-        aria-expanded="false"
-        aria-controls="collapseMentionsHelp">
+       href="#collapseMentionsHelp{{ id }}"
+       role="button"
+       aria-expanded="false"
+       aria-controls="collapseMentionsHelp{{ id }}">
         mention d'informations
     </a>
     sur les champs libres

--- a/lacommunaute/templates/partials/form_field_mentions.html
+++ b/lacommunaute/templates/partials/form_field_mentions.html
@@ -9,7 +9,7 @@
     sur les champs libres
 </small>
 
-<div class="collapse" id="collapseMentionsHelp">
+<div class="collapse" id="collapseMentionsHelp{{ id }}">
     <div class="mb-3">
         <p>
             Nous vous demandons de ne pas nous transmettre d’informations sensibles. Notamment, ne communiquez pas vos opinions philosophiques, syndicales, politiques ou sur votre vie sexuelle. Ces données sont trop personnelles !

--- a/lacommunaute/templates/partials/social_share_buttons.html
+++ b/lacommunaute/templates/partials/social_share_buttons.html
@@ -1,7 +1,7 @@
 {% load i18n %}
 {% load social_share %}
 
-<button class="btn btn-sm btn-ico-only btn-secondary" type="button" id="dropdownMenuSocialShare" data-bs-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+<button class="btn btn-sm btn-ico-only btn-secondary" type="button" id="dropdownMenuSocialShare{{ id }}" data-bs-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
     <i class="ri-share-fill ri-lg" aria-label="{% trans "Share this topics on " %}"></i>
 </button>
 <div class="dropdown-menu dropdown-menu-end" aria-labelledby="dropdownMenuSocialShare">

--- a/lacommunaute/templates/partials/social_share_buttons.html
+++ b/lacommunaute/templates/partials/social_share_buttons.html
@@ -4,7 +4,7 @@
 <button class="btn btn-sm btn-ico-only btn-secondary" type="button" id="dropdownMenuSocialShare{{ id }}" data-bs-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
     <i class="ri-share-fill ri-lg" aria-label="{% trans "Share this topics on " %}"></i>
 </button>
-<div class="dropdown-menu dropdown-menu-end" aria-labelledby="dropdownMenuSocialShare">
+<div class="dropdown-menu dropdown-menu-end" aria-labelledby="dropdownMenuSocialShare{{ id }}">
     {% post_to_facebook instance '<i class="ri-facebook-fill ri-lg"></i> Partager sur Facebook' %}
     {% post_to_whatsapp instance '<i class="ri-whatsapp-line ri-lg"></i> Partager sur Whatsapp' %}
     {% post_to_twitter text instance '<i class="ri-twitter-line ri-lg"></i> Partager sur Twitter' %}


### PR DESCRIPTION
## Description

🎸 Supprimer les ID en doublons dans les templates `social_share_buttons` et `form_field_mentions`. Ces templates sont inclus pour chaque sujet dans les listes de `topic`

## Type de changement

🪲 Correction de bug (changement non cassant qui corrige un problème).
🚧 technique

### Points d'attention

🦺 l'ID du `Topic` dans `form_field_mentions` est initié par le template `post_feed_form_collapsable`, et transmis via le template `form_field`


