### PR TITLE
[CONVERSATION] gérer les fichiers manquants

### DIFF
--- a/lacommunaute/templates/forum_conversation/forum_attachments/attachments_detail.html
+++ b/lacommunaute/templates/forum_conversation/forum_attachments/attachments_detail.html
@@ -6,14 +6,18 @@
 {% if post.attachments.exists and user_can_download_files %}
     <div class="row attachments mt-3 mt-md-5">
         {% for attachment in post.attachments.all %}
-            {% if not attachment|is_image %}
-                <div class="col-md-12 attachment">
-                    <a href="{% url 'forum_conversation:attachment' pk=attachment.id %}"><i class="fa fa-file"></i>&nbsp;{{ attachment.filename }} ({{ attachment.file.size|filesizeformat }})</a>
-                    {% if attachment.comment %}
-                        <p class="text-muted"><em>{{ attachment.comment }}</em></p>
-                    {% endif %}
-                </div>
-            {% endif%}
+            {% if attachment|is_available %}
+                {% if not attachment|is_image %}
+                    <div class="col-md-12 attachment">
+                        <a href="{% url 'forum_conversation:attachment' pk=attachment.id %}"><i class="fa fa-file"></i>&nbsp;{{ attachment.filename }} ({{ attachment.file.size|filesizeformat }})</a>
+                        {% if attachment.comment %}
+                            <p class="text-muted"><em>{{ attachment.comment }}</em></p>
+                        {% endif %}
+                    </div>
+                {% endif%}
+            {% else %}
+                <p class="text-muted"><i class="ri-file-damage-fill"></i>&nbsp;{{ attachment.filename }}</p>
+            {% endif %}
         {% endfor %}
     </div>
 {% endif %}

--- a/lacommunaute/utils/templatetags/attachments_tags.py
+++ b/lacommunaute/utils/templatetags/attachments_tags.py
@@ -13,3 +13,8 @@ def is_image(object):
         return True
     else:
         return False
+
+
+@register.filter
+def is_available(object):
+    return object.file.field.storage.exists(object.file.name)


### PR DESCRIPTION
## Description

🎸 afficher l'icone `damage file` et le nom du fichier si le fichier n'est pas trouvé dans le repertoire de stockage, au lieu de faire planter le template

## Type de changement

🪲 Correction de bug (changement non cassant qui corrige un problème).
🚧 technique

### Points d'attention

🦺 Cas fréquent lors du restore de la DB en local, sans les fichiers associés
🦺 Pourrait se produire en prod en cas d'effacement de tout ou partie du S3

### Captures d'écran (optionnel)

Fichier présent

![image](https://github.com/betagouv/itou-communaute-django/assets/11419273/69859a92-fd78-4f6f-a3f9-5c11a778897c)


Fichier absent

![image](https://github.com/betagouv/itou-communaute-django/assets/11419273/60f34ce4-52e3-46f5-822b-e1ad3a96db85)

