### PR TITLE
[LOGIN IC] gérer les redirections après authentification

### DIFF
--- a/lacommunaute/event/tests/tests_views.py
+++ b/lacommunaute/event/tests/tests_views.py
@@ -11,7 +11,6 @@ from lacommunaute.event.factories import EventFactory
 from lacommunaute.event.forms import EventModelForm
 from lacommunaute.event.models import Event
 from lacommunaute.users.factories import UserFactory
-from lacommunaute.utils.templatetags.str_filters import inclusion_connect_url
 
 
 faker = Faker()
@@ -234,8 +233,4 @@ class calendar_test(TestCase):
     def test_template(self):
         response = self.client.get(reverse("event:calendar"))
         self.assertTemplateUsed(response, "event/event_calendar.html")
-        self.assertContains(response, inclusion_connect_url(reverse("event:create")))
-
-        self.client.force_login(UserFactory())
-        response = self.client.get(reverse("event:calendar"))
         self.assertContains(response, reverse("event:create"))

--- a/lacommunaute/event/views.py
+++ b/lacommunaute/event/views.py
@@ -99,4 +99,4 @@ def calendar_data(request):
 
 
 def calendar(request):
-    return TemplateResponse(request, "event/event_calendar.html", {"next_url": reverse("event:create")})
+    return TemplateResponse(request, "event/event_calendar.html")

--- a/lacommunaute/forum/tests/tests_views.py
+++ b/lacommunaute/forum/tests/tests_views.py
@@ -151,7 +151,7 @@ class ForumViewTest(TestCase):
         self.assertContains(response, '<i class="ri-heart-3-line me-1" aria-hidden="true"></i><span>0</span>')
 
     def test_anonymous_like(self):
-        params = {"next_url": self.url}
+        params = {"next": self.url}
         url = f"{reverse('inclusion_connect:authorize')}?{urlencode(params)}"
 
         response = self.client.get(self.url)
@@ -352,7 +352,7 @@ class ForumViewTest(TestCase):
 
         # anonymous
         anonymous_html = (
-            '<a href="/inclusion_connect/authorize?next_url=%2Fforum%2F'
+            '<a href="/inclusion_connect/authorize?next=%2Fforum%2F'
             f'{child_forum.slug}-{child_forum.pk}%2F%23{child_forum.pk}"'
             ' rel="nofollow"'
             ' class="btn btn-sm btn-ico-only btn-link btn-secondary" data-bs-toggle="tooltip" data-bs-placement="top"'

--- a/lacommunaute/forum_conversation/tests/tests_views.py
+++ b/lacommunaute/forum_conversation/tests/tests_views.py
@@ -409,7 +409,7 @@ class TopicViewTest(TestCase):
 
     def test_anonymous_like(self):
         assign_perm("can_read_forum", AnonymousUser(), self.topic.forum)
-        params = {"next_url": self.url}
+        params = {"next": self.url}
         url = f"{reverse('inclusion_connect:authorize')}?{urlencode(params)}"
 
         response = self.client.get(self.url)

--- a/lacommunaute/inclusion_connect/tests/tests_views.py
+++ b/lacommunaute/inclusion_connect/tests/tests_views.py
@@ -47,7 +47,7 @@ def mock_oauth_dance(
     respx.get(constants.INCLUSION_CONNECT_ENDPOINT_AUTHORIZE).respond(302)
     authorize_params = {
         "previous_url": previous_url,
-        "next_url": next_url,
+        "next": next_url,
     }
     authorize_params = {k: v for k, v in authorize_params.items() if v}
 

--- a/lacommunaute/inclusion_connect/views.py
+++ b/lacommunaute/inclusion_connect/views.py
@@ -49,7 +49,7 @@ def _redirect_to_login_page_on_error(error_msg, request=None):
 def inclusion_connect_authorize(request):
     # Start a new session.
     previous_url = request.GET.get("previous_url", reverse("pages:home"))
-    next_url = request.GET.get("next_url")
+    next_url = request.GET.get("next")
     sign_in = bool(request.GET.get("sign_in", False))
 
     ic_session = InclusionConnectSession(previous_url=previous_url, next_url=next_url)

--- a/lacommunaute/templates/event/event_calendar.html
+++ b/lacommunaute/templates/event/event_calendar.html
@@ -31,16 +31,10 @@
         <div class="s-section__container container">
             <div class="s-section__row row">
                 <div class="s-section__col col-12">
-                    {% if user.is_authenticated %}
-                        <a href="{% url 'event:create' %}"
-                            role="button" class="btn btn-primary">
-                            {% trans "Post a new Public Event" %}
-                        </a>
-                    {% else %}
-                        <a href="{% inclusion_connect_url next_url %}" rel="nofollow" class="btn btn-primary" data-bs-toggle="tooltip" data--bs-placement="top" title="Connectez-vous pour contribuer">
-                            {% trans "Post a new Public Event" %}
-                        </a>
-                    {% endif %}
+                    <a href="{% url 'event:create' %}"  rel="nofollow"
+                       role="button" class="btn btn-primary">
+                        {% trans "Post a new Public Event" %}
+                    </a>
                 </div>
             </div>
         </div>

--- a/lacommunaute/utils/templatetags/str_filters.py
+++ b/lacommunaute/utils/templatetags/str_filters.py
@@ -35,7 +35,7 @@ def pluralizefr(value, arg="s"):
 def inclusion_connect_url(next_url, anchor=None):
     if anchor:
         next_url = f"{next_url}#{anchor}"
-    params = {"next_url": next_url}
+    params = {"next": next_url}
     return f"{reverse('inclusion_connect:authorize')}?{urlencode(params)}"
 
 

--- a/lacommunaute/utils/tests.py
+++ b/lacommunaute/utils/tests.py
@@ -114,11 +114,11 @@ class UtilsTemplateTagsTestCase(TestCase):
         context = Context({"next_url": next_url, "anchor": anchor})
 
         out = Template("{% load str_filters %}{% inclusion_connect_url next_url%}").render(context)
-        params = {"next_url": next_url}
+        params = {"next": next_url}
         self.assertEqual(out, f"{inclusion_connect_url}?{urlencode(params)}")
 
         out = Template("{% load str_filters %}{% inclusion_connect_url next_url anchor %}").render(context)
-        params = {"next_url": f"{next_url}#{anchor}"}
+        params = {"next": f"{next_url}#{anchor}"}
         self.assertEqual(out, f"{inclusion_connect_url}?{urlencode(params)}")
 
     def test_relativetimesince_fr(self):


### PR DESCRIPTION
## Description

🎸 aligner le `redirect_field_name` utilisé dans l'app `inclusion_connect` avec celui de l'authentification django pour rediriger correctement l'utilisateur lors de sa tentative d'accès à une vue requierant son authentification

## Type de changement

🪲 Correction de bug (changement non cassant qui corrige un problème).
🚧 technique

### Points d'attention

🦺 ne s'applique pas aux vues HTMX requierant authentification (à traiter dans un temps ultérieur)



