### PR TITLE
[CONVERSATION] masquer le bouton "voir les 999 reponses" (fix)

### DIFF
--- a/lacommunaute/templates/forum_conversation/partials/posts_list.html
+++ b/lacommunaute/templates/forum_conversation/partials/posts_list.html
@@ -37,8 +37,3 @@
         {% include "forum_conversation/partials/post_feed_form_collapsable.html" with post_form=form inline=1 %}
     </div>
 </div>
-
-<script>
-    document.getElementById(`collapseButtonPost{{topic.pk}}`).setAttribute('aria-expanded', 'false');
-    document.getElementById(`showmoreposts-button{{topic.pk}}`).className = 'd-none';
-</script>

--- a/lacommunaute/templates/forum_conversation/partials/posts_list.html
+++ b/lacommunaute/templates/forum_conversation/partials/posts_list.html
@@ -9,7 +9,7 @@
 <div id="showmorepostsarea{{topic.pk}}">
     {% for post in posts %}
         <div class="card post mb-3 {% if post.is_certified %}bg-communaute-lighter border-communaute {% else %}bg-light {% endif %} has-links-inside ms-3"
-            id="certifiedpostsarea{{post.pk}}">
+             id="certifiedpostsarea{{post.pk}}">
             <div class="card-body">
                 <div class="row">
                     <div class="col-12 post-content-wrapper">

--- a/lacommunaute/templates/forum_conversation/partials/topic_detail_actions.html
+++ b/lacommunaute/templates/forum_conversation/partials/topic_detail_actions.html
@@ -26,7 +26,6 @@
        data-matomo-category="engagement"
        data-matomo-action="showmore"
        data-matomo-option="post"
-       onclick=DisabledMe("showmoreposts-button{{topic.pk}}")
        aria-label="{% trans "Show me the comment" %}"
        role="button"
     >
@@ -64,10 +63,3 @@
         {% endif %}
     </div>
 {% endif %}
-
-
-<script>
-    function DisabledMe(id) {
-        document.getElementById(id).classList.add('disabled');
-    }
-</script>

--- a/lacommunaute/templates/forum_conversation/partials/topic_detail_actions.html
+++ b/lacommunaute/templates/forum_conversation/partials/topic_detail_actions.html
@@ -19,16 +19,16 @@
 
 {% if posts_count > 1 %}
     <a hx-get="{% url 'forum_conversation_extension:showmore_posts' topic.forum.slug topic.forum.pk topic.slug topic.pk %}"
-        id="showmoreposts-button{{topic.pk}}"
-        hx-target="#showmorepostsarea{{topic.pk}}"
-        hx-swap="outerHTML"
-        class="btn btn-secondary btn-sm btn-ico matomo-event justify-content-center w-100 w-sm-auto me-sm-1 mb-2 mb-sm-0"
-        data-matomo-category="engagement"
-        data-matomo-action="showmore"
-        data-matomo-option="post"
-        onclick=DisabledMe("showmoreposts-button{{topic.pk}}")
-        aria-label="{% trans "Show me the comment" %}"
-        role="button"
+       id="showmoreposts-button{{topic.pk}}"
+       hx-target="#showmorepostsarea{{topic.pk}}"
+       hx-swap="outerHTML"
+       class="btn btn-secondary btn-sm btn-ico matomo-event justify-content-center w-100 w-sm-auto me-sm-1 mb-2 mb-sm-0 showmoreposts-button"
+       data-matomo-category="engagement"
+       data-matomo-action="showmore"
+       data-matomo-option="post"
+       onclick=DisabledMe("showmoreposts-button{{topic.pk}}")
+       aria-label="{% trans "Show me the comment" %}"
+       role="button"
     >
         <i class="ri-eye-line font-weight-normal" aria-hidden="true"></i>
         <span>

--- a/lacommunaute/templates/forum_conversation/topic_list.html
+++ b/lacommunaute/templates/forum_conversation/topic_list.html
@@ -136,3 +136,10 @@
         {% endif %}
     {% endif %}
 </div>
+
+<script nonce="{{ request.csp_nonce }}">
+    var showmorepostsButtons = document.querySelectorAll('.showmoreposts-button')
+    showmorepostsButtons.forEach((button) => button.addEventListener('click', function () {
+        button.classList.add('d-none');
+    }));
+</script>


### PR DESCRIPTION
## Description

🎸 nettoyage des scripts : 
1. suppression du code mort : `onclick=DisabledMe` en prévision de l'application des Content Security Policies
2. insertion unique du script d'ajout de la classe `d-none` au bouton en objet au niveau du template `topic_list.html` au lieu de `posts_list.html` pour éviter la duplication du code dans la page rendu ET une erreur dans la vue de détail d'un `topic`

## Type de changement

🚧 technique

