### PR TITLE
Content Security Policies - patch

### DIFF
--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -360,7 +360,7 @@ CSP_STYLE_SRC_ELEM = CSP_STYLE_SRC
 CSP_FONT_SRC = ("'self'", "https://fonts.gstatic.com/", "data:")
 CSP_SCRIPT_SRC = (
     "'self'",
-    "https://cdn.jsdelivr.net",
+    "https://cdn.jsdelivr.net/npm/chart.js",
     "https://tally.so",
     "https://stats.data.gouv.fr/piwik.js",
 )

--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -362,6 +362,7 @@ CSP_SCRIPT_SRC = (
     "'self'",
     "https://cdn.jsdelivr.net",
     "https://tally.so",
+    "https://stats.data.gouv.fr/piwik.js",
 )
 CSP_SCRIPT_SRC_ELEM = CSP_SCRIPT_SRC
 CSP_FRAME_SRC = ("'self'", "https://tally.so")


### PR DESCRIPTION
## Description

🦺 autoriser explicitement `https://stats.data.gouv.fr/piwik.js` pour réactiver les stats matomo
🦺 limiter l'autorisation de `https://cdn.jsdelivr.net` à `https://cdn.jsdelivr.net/npm/chart.js`


## Type de changement

🚧 technique
