### PR TITLE
 Content Security Policies - patch 4 - matomo stats

### DIFF
--- a/.github/workflows/review-app-creation.yml
+++ b/.github/workflows/review-app-creation.yml
@@ -68,7 +68,6 @@ jobs:
     - name: 🤝 Link addons & add environment variables
       run: |
         $CLEVER_CLI link $REVIEW_APP_NAME --org $REVIEW_APPS_ORGANIZATION_NAME
-        $CLEVER_CLI env set COMMU_ENVIRONMENT "REVIEW-APP"
         $CLEVER_CLI env set COMMU_FQDN "${{ env.DEPLOY_URL }}"
         $CLEVER_CLI env set S3_STORAGE_BUCKET_NAME c3-django-review-bucket
         $CLEVER_CLI env set S3_STORAGE_BUCKET_NAME_PUBLIC c3-django-review-bucket-public

--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -242,8 +242,6 @@ CACHES = {
     },
 }
 
-# Environment, sets the type of env of the app (PROD, DEV…)
-COMMU_ENVIRONMENT = os.getenv("COMMU_ENVIRONMENT", "PROD")
 COMMU_PROTOCOL = "https"
 COMMU_FQDN = os.getenv("COMMU_FQDN", "communaute.inclusion.beta.gouv.fr")
 
@@ -359,7 +357,6 @@ TAGGIT_STRIP_UNICODE_WHEN_SLUGIFY = True
 CSP_DEFAULT_SRC = ("'self'",)
 # unsafe-inline for htmx.js, embed.js & tartecitron.js needs
 CSP_STYLE_SRC = ("'self'", "https://fonts.googleapis.com", "'unsafe-inline'")
-CSP_STYLE_SRC_ELEM = CSP_STYLE_SRC
 CSP_FONT_SRC = ("'self'", "https://fonts.gstatic.com/", "data:")
 CSP_SCRIPT_SRC = (
     "'self'",
@@ -368,12 +365,19 @@ CSP_SCRIPT_SRC = (
     "https://cdn.jsdelivr.net/npm/@popperjs/core@2.11.8/dist/umd/popper.min.js",
     "https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.min.js",
     "https://tally.so",
-    "https://stats.data.gouv.fr/piwik.js",
 )
-CSP_SCRIPT_SRC_ELEM = CSP_SCRIPT_SRC
 CSP_FRAME_SRC = ("'self'", "https://tally.so")
 CSP_IMG_SRC = ("'self'", "data:", "cellar-c2.services.clever-cloud.com")
+CSP_CONNECT_SRC = ("'self'", "*.sentry.io")
 CSP_INCLUDE_NONCE_IN = ["script-src", "script-src-elem"]
+
+if MATOMO_BASE_URL:
+    CSP_IMG_SRC += (MATOMO_BASE_URL,)
+    CSP_SCRIPT_SRC += (MATOMO_BASE_URL,)
+    CSP_CONNECT_SRC += (MATOMO_BASE_URL,)
+
+CSP_SCRIPT_SRC_ELEM = CSP_SCRIPT_SRC
+CSP_STYLE_SRC_ELEM = CSP_STYLE_SRC
 
 # HSTS
 # ---------------------------------------

--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -328,9 +328,7 @@ SITE_ID = 1
 # ---------------------------------------
 MATOMO_BASE_URL = os.getenv("MATOMO_BASE_URL", None)
 MATOMO_SITE_ID = int(os.getenv("MATOMO_SITE_ID", "1"))
-
-if MATOMO_BASE_URL:
-    MATOMO_AUTH_TOKEN = os.getenv("MATOMO_AUTH_TOKEN")
+MATOMO_AUTH_TOKEN = os.getenv("MATOMO_AUTH_TOKEN", None)
 
 # SENDINBLUE
 # ---------------------------------------

--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -328,8 +328,11 @@ SITE_ID = 1
 
 # MATOMO
 # ---------------------------------------
-MATOMO_SITE_ID = 268
-MATOMO_URL = "https://stats.data.gouv.fr/index.php"
+MATOMO_BASE_URL = os.getenv("MATOMO_BASE_URL", None)
+MATOMO_SITE_ID = int(os.getenv("MATOMO_SITE_ID", "1"))
+
+if MATOMO_BASE_URL:
+    MATOMO_AUTH_TOKEN = os.getenv("MATOMO_AUTH_TOKEN")
 
 # SENDINBLUE
 # ---------------------------------------

--- a/config/settings/dev.py
+++ b/config/settings/dev.py
@@ -82,5 +82,3 @@ STORAGES = {
     "default": {"BACKEND": "django.core.files.storage.FileSystemStorage"},
     "staticfiles": {"BACKEND": "django.contrib.staticfiles.storage.StaticFilesStorage"},
 }
-
-COMMU_ENVIRONMENT = "DEV"

--- a/lacommunaute/templates/layouts/base.html
+++ b/lacommunaute/templates/layouts/base.html
@@ -150,8 +150,8 @@
 
                 {% if COMMU_ENVIRONMENT == 'PROD' %}
                     // Matomo :
-                    tarteaucitron.user.matomoId = 268;
-                    tarteaucitron.user.matomoHost = "https://stats.data.gouv.fr/";
+                    tarteaucitron.user.matomoId = {{ MATOMO_SITE_ID }};
+                    tarteaucitron.user.matomoHost = '{{ MATOMO_BASE_URL }}';
                     (tarteaucitron.job = tarteaucitron.job || []).push('matomo');
                 {% endif %}
             </script>

--- a/lacommunaute/templates/layouts/base.html
+++ b/lacommunaute/templates/layouts/base.html
@@ -148,14 +148,14 @@
                     "mandatoryCta": true /* Show the disabled accept button when mandatory on */
                 });
 
-                {% if COMMU_ENVIRONMENT == 'PROD' %}
+                {% if MATOMO_BASE_URL %}
                     // Matomo :
                     tarteaucitron.user.matomoId = {{ MATOMO_SITE_ID }};
                     tarteaucitron.user.matomoHost = '{{ MATOMO_BASE_URL }}';
                     (tarteaucitron.job = tarteaucitron.job || []).push('matomo');
                 {% endif %}
             </script>
-            {% if COMMU_ENVIRONMENT == 'PROD' %}
+            {% if MATOMO_BASE_URL %}
                 <script type="text/javascript" src="{% static 'javascripts/matomo.js' %}" defer></script>
             {% endif %}
             <script type="text/javascript" src="{% static 'vendor/htmx-1.9.5/htmx.min.js' %}" defer></script>

--- a/lacommunaute/utils/matomo.py
+++ b/lacommunaute/utils/matomo.py
@@ -1,3 +1,4 @@
+import os
 from datetime import date
 
 import httpx
@@ -11,7 +12,7 @@ def get_matomo_data(
     period,
     search_date,
     method,
-    token_auth="anonymous",
+    token_auth=settings.MATOMO_AUTH_TOKEN,
     **kwargs,
 ):
     """
@@ -34,7 +35,7 @@ def get_matomo_data(
         "filter_limit": -1,
         **kwargs,
     }
-    response = httpx.get(settings.MATOMO_URL, params=params)
+    response = httpx.get(os.path.join(settings.MATOMO_BASE_URL, "index.php"), params=params)
 
     if response.status_code != 200:
         raise Exception(f"Matomo API error: {response.text}")

--- a/lacommunaute/utils/settings_context_processors.py
+++ b/lacommunaute/utils/settings_context_processors.py
@@ -11,7 +11,6 @@ def expose_settings(request):
     return {
         "BASE_TEMPLATE": base_template,
         "ALLOWED_HOSTS": settings.ALLOWED_HOSTS,
-        "COMMU_ENVIRONMENT": settings.COMMU_ENVIRONMENT,
         "MATOMO_SITE_ID": settings.MATOMO_SITE_ID,
         "MATOMO_BASE_URL": settings.MATOMO_BASE_URL,
     }

--- a/lacommunaute/utils/settings_context_processors.py
+++ b/lacommunaute/utils/settings_context_processors.py
@@ -12,4 +12,6 @@ def expose_settings(request):
         "BASE_TEMPLATE": base_template,
         "ALLOWED_HOSTS": settings.ALLOWED_HOSTS,
         "COMMU_ENVIRONMENT": settings.COMMU_ENVIRONMENT,
+        "MATOMO_SITE_ID": settings.MATOMO_SITE_ID,
+        "MATOMO_BASE_URL": settings.MATOMO_BASE_URL,
     }

--- a/lacommunaute/utils/tests.py
+++ b/lacommunaute/utils/tests.py
@@ -206,6 +206,7 @@ class UtilsTemplateTagsTestCase(TestCase):
 
 
 class UtilsGetMatomoDataTest(TestCase):
+    @override_settings(MATOMO_BASE_URL="https://matomo.example.com")
     def test_get_matomo_data(self):
         nb_uniq_visitors = faker.random_int()
         with patch("lacommunaute.utils.matomo.httpx.get") as mock_get:


### PR DESCRIPTION
## Description

🎸 rétablir l'envoi des stats d'activités vers matomo : correction des CSP
🎸 rendre paramétrables (url et token) l'envoi des stats vers l'instance matomo choisie

## Type de changement

🪲 Correction de bug
🚧 technique

### Points d'attention

🦺 mise à jour de la gestion du token d'authentification dans `get_matomo_data`
🦺 ajouter `MATOMO_SITE_ID`, `MATOMO_BASE_URL` et `MATOMO_AUTH_TOKEN` dans les variables d'env clevercloud
🦺 Suppression de la variable `COMMU_ENVIRONMENT` devenue inutile