### PR TITLE
[TECH] fiabilisation d'un test

### DIFF
--- a/lacommunaute/forum/tests/tests_views.py
+++ b/lacommunaute/forum/tests/tests_views.py
@@ -1,3 +1,4 @@
+from django.contrib.contenttypes.models import ContentType
 from django.template.defaultfilters import truncatechars_html
 from django.test import RequestFactory, TestCase
 from django.urls import reverse
@@ -227,9 +228,11 @@ class ForumViewTest(TestCase):
         self.assertNotContains(response, f'id="collapsePost{self.topic.pk}')
 
     def test_queries(self):
+        ContentType.objects.clear_cache()
+
         TopicFactory.create_batch(20, with_post=True)
         self.client.force_login(self.user)
-        with self.assertNumQueries(22):
+        with self.assertNumQueries(23):
             self.client.get(self.url)
 
     def test_certified_post_display(self):


### PR DESCRIPTION
## Description

🎸 [`test_numqueries`](https://github.com/betagouv/itou-communaute-django/blob/866cc91e30261b48d72b538ae8766f488a88bb19/lacommunaute/forum/tests/tests_views.py#L229) dénombre les requêtes de la vue `ForumView`. Selon le type de lancement (unitaire ou dans la suite de test), le chargement du `Content_Type` est inclus dénombré ou pas dans ce test.
🎸 Solution : vider le cache systématiquement lors du lancement de ce test, pour rendre le dénombrement reproductible.


## Type de changement

🪲 Correction de bug (changement non cassant qui corrige un problème).
🚧 technique

### Points d'attention

🦺 Pourrait concerné les autres vues liées à l'utilisation de `Upvote`. À traiter au cas par cas.
