### PR TITLE
[Evenement] patch #1

### DIFF
--- a/lacommunaute/event/tests/tests_views.py
+++ b/lacommunaute/event/tests/tests_views.py
@@ -226,6 +226,10 @@ class EventMonthArchiveViewTest(TestCase):
         response = self.client.get(reverse("event:month", kwargs={"year": event.date.year, "month": event.date.month}))
         self.assertContains(response, event.name, status_code=200)
 
+    def test_allow_empty(self):
+        response = self.client.get(reverse("event:month", kwargs={"year": 2000, "month": 1}))
+        self.assertContains(response, "Aucun évènement", status_code=200, html=True)
+
     def test_navbar(self):
         event = EventFactory(date=timezone.now())
         event_in_the_future = EventFactory(date=event.date + relativedelta(months=1))

--- a/lacommunaute/event/tests/tests_views.py
+++ b/lacommunaute/event/tests/tests_views.py
@@ -224,9 +224,13 @@ class EventMonthArchiveViewTest(TestCase):
         self.assertContains(response, reverse("event:create"))
 
     def test_view_with_args(self):
-        event = EventFactory(date=timezone.now() + relativedelta(months=1))
-        response = self.client.get(reverse("event:month", kwargs={"year": event.date.year, "month": event.date.month}))
-        self.assertContains(response, event.name, status_code=200)
+        event = EventFactory(date=timezone.now())
+        old_event = EventFactory(date=timezone.now() - relativedelta(months=1))
+        response = self.client.get(
+            reverse("event:month", kwargs={"year": old_event.date.year, "month": old_event.date.month})
+        )
+        self.assertNotContains(response, event.name, status_code=200)
+        self.assertContains(response, old_event.name, status_code=200)
 
     def test_allow_empty(self):
         response = self.client.get(reverse("event:month", kwargs={"year": 2000, "month": 1}))

--- a/lacommunaute/event/tests/tests_views.py
+++ b/lacommunaute/event/tests/tests_views.py
@@ -232,6 +232,11 @@ class EventMonthArchiveViewTest(TestCase):
         self.assertNotContains(response, event.name, status_code=200)
         self.assertContains(response, old_event.name, status_code=200)
 
+    def test_allow_future(self):
+        event = EventFactory(date=timezone.now() + relativedelta(months=1))
+        response = self.client.get(reverse("event:month", kwargs={"year": event.date.year, "month": event.date.month}))
+        self.assertContains(response, event.name, status_code=200)
+
     def test_allow_empty(self):
         response = self.client.get(reverse("event:month", kwargs={"year": 2000, "month": 1}))
         self.assertContains(response, "Aucun évènement", status_code=200, html=True)

--- a/lacommunaute/event/views.py
+++ b/lacommunaute/event/views.py
@@ -72,6 +72,7 @@ class EventDetailView(DetailView):
 
 class EventMonthArchiveView(MonthArchiveView):
     allow_future = True
+    allow_empty = True
     date_field = "date"
     queryset = Event.objects.all()
     month_format = "%m"

--- a/lacommunaute/templates/event/event_archive_month.html
+++ b/lacommunaute/templates/event/event_archive_month.html
@@ -1,6 +1,7 @@
 {% extends "layouts/base.html" %}
 {% load i18n %}
 
+{% block title %}{% trans "Events" %}{{ block.super }}{% endblock %}
 {% block sub_title %}{% trans "Events" %} {{ month }}{% endblock sub_title %}
 
 {% block content %}


### PR DESCRIPTION
## Description

🎸 afficher le message "aucun évènement" au lieu d'une `404` pour un mois sans evènement.
🎸 ajouter un `title` à la vue `EventMonthArchiveView`

## Type de changement

🪲 Correction de bug (changement non cassant qui corrige un problème).
🚧 technique

